### PR TITLE
[WIP] Add bookmarklet to highlight templates

### DIFF
--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -86,7 +86,8 @@ describe("PopupView.generateContentLinks", function () {
 
     expect(urls).toContain(
       "https://www.gov.uk/smart-answer/y/question-1.txt",
-      "https://www.gov.uk/smart-answer/y/visualise"
+      "https://www.gov.uk/smart-answer/y/visualise",
+      "javascript: if (typeof(linkToTemplatesOnGithub) === 'function') { linkToTemplatesOnGithub(); };"
     )
   })
 

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -35,7 +35,10 @@ Popup.generateContentLinks = function(location, currentEnvironment, renderingApp
 
   if (renderingApplication == "smartanswers") {
     if (currentUrl.match(/\/y\/?.*$/)) {
+      linkToTemplateOnGithub = "javascript: if (typeof(linkToTemplatesOnGithub) === 'function') { linkToTemplatesOnGithub(); };"
+
       links.push({ name: "SmartAnswers: Display GovSpeak", url: currentUrl + ".txt"})
+      links.push({ name: "SmartAnswers: Link(s) to Github", url: linkToTemplateOnGithub })
     }
 
     links.push({ name: "SmartAnswers: Visualise", url: currentUrl.replace(/\/y.*$/, "") + "/y/visualise" })


### PR DESCRIPTION
When a content designer needs to edit smart answer content, they find
it difficult to find the relevant templates and partials that a
particular outcome or question uses.

This commits makes it possible for content designers to highlight the
templates and partials that a smart answer outcome or question has.

This has been done by providing a bookmarklet [1] that invokes the
linkToTemplatesOnGithub function.

[1] https://bl.ocks.org/floehopper/91b990d66bfae1dbdbaa88aa4772f1a9

## Depends on

- [ ] https://github.com/alphagov/smart-answers/pull/3295
