### PR TITLE
Update component highlighting

### DIFF
--- a/spec/javascripts/fixtures/gem-c-breadcrumbs.html
+++ b/spec/javascripts/fixtures/gem-c-breadcrumbs.html
@@ -1,4 +1,4 @@
-<div class="govuk-breadcrumbs " data-module="track-click">
+<div class="gem-c-breadcrumbs " data-module="track-click">
   <ol>
     <li class="">
       <a data-track-category="breadcrumbClicked" data-track-action="1" data-track-label="/section" data-track-options="{&quot;dimension28&quot;:&quot;2&quot;,&quot;dimension29&quot;:&quot;Section&quot;}" class="" aria-current="false" href="/section">Section</a>

--- a/spec/javascripts/fixtures/gem-c-button.html
+++ b/spec/javascripts/fixtures/gem-c-button.html
@@ -1,0 +1,3 @@
+<button class="gem-c-button">
+  Submit
+</button>

--- a/spec/javascripts/fixtures/pub-c-button.html
+++ b/spec/javascripts/fixtures/pub-c-button.html
@@ -1,3 +1,0 @@
-<button class="pub-c-button">
-  Submit
-</button>

--- a/spec/javascripts/highlight_component_spec.js
+++ b/spec/javascripts/highlight_component_spec.js
@@ -199,4 +199,15 @@ describe("Helpers.documentationUrl", function () {
       "https://govuk-publishing-components.herokuapp.com/component-guide/label"
     )
   });
+
+  it("creates the correct URL for Design System components", function () {
+    expect(
+      Helpers.documentationUrl({
+        prefix: "govuk-",
+        name: "error-message"
+      })
+    ).toEqual(
+      "https://design-system.service.gov.uk/components/error-message"
+    )
+  });
 });

--- a/spec/javascripts/highlight_component_spec.js
+++ b/spec/javascripts/highlight_component_spec.js
@@ -5,7 +5,7 @@ describe("Toggling component highlighting", function () {
   var highlightComponent;
 
   beforeEach(function () {
-    loadFixtures("govuk-breadcrumbs.html")
+    loadFixtures("gem-c-breadcrumbs.html")
 
     // Mock addListener function to call toggleComponents trigger when initialized
     window.chrome = {
@@ -21,7 +21,7 @@ describe("Toggling component highlighting", function () {
 
     highlightComponent = new HighlightComponent;
 
-    $breadcrumbsEl = $("#jasmine-fixtures .govuk-breadcrumbs");
+    $breadcrumbsEl = $("#jasmine-fixtures .gem-c-breadcrumbs");
   });
 
   it("highlights govuk components", function () {
@@ -33,7 +33,7 @@ describe("Toggling component highlighting", function () {
   });
 
   it("exposes the app name as data attribute", function () {
-    expect($breadcrumbsEl.data("app-name")).toEqual("govuk-");
+    expect($breadcrumbsEl.data("app-name")).toEqual("gem-c-");
   });
 
   it("adds the ability to click through to the component's documentation", function () {
@@ -44,7 +44,7 @@ describe("Toggling component highlighting", function () {
 
     expect(clickEvent).toHaveBeenTriggered();
     expect(window.open).toHaveBeenCalledWith(
-      "https://govuk-static.herokuapp.com/component-guide/breadcrumbs"
+      "https://govuk-publishing-components.herokuapp.com/component-guide/breadcrumbs"
     )
   });
 
@@ -85,8 +85,8 @@ describe("highlightComponent", function () {
     beforeEach(function () {
       loadFixtures(
         "app-c-back-to-top.html",
-        "govuk-breadcrumbs.html",
-        "pub-c-button.html",
+        "gem-c-breadcrumbs.html",
+        "gem-c-button.html",
         "gem-c-label.html"
       )
 
@@ -105,13 +105,13 @@ describe("highlightComponent", function () {
           },
           {
             name: "breadcrumbs",
-            prefix: "govuk-",
-            element: $html.find(".govuk-breadcrumbs")[0],
+            prefix: "gem-c-",
+            element: $html.find(".gem-c-breadcrumbs")[0],
           },
           {
             name: "button",
-            prefix: "pub-c-",
-            element: $html.find(".pub-c-button")[0],
+            prefix: "gem-c-",
+            element: $html.find(".gem-c-button")[0],
           },
           {
             name: "label",
@@ -138,11 +138,11 @@ describe("highlightComponent", function () {
     });
 
     it("toggles the highlight-component class", function () {
-      loadFixtures("pub-c-button.html");
+      loadFixtures("gem-c-button.html");
 
       var highlightComponent = new HighlightComponent;
 
-      var $buttonEl = $("#jasmine-fixtures .pub-c-button");
+      var $buttonEl = $("#jasmine-fixtures .gem-c-button");
       expect($buttonEl).not.toHaveClass("highlight-component");
 
       highlightComponent.toggleComponents();
@@ -185,17 +185,6 @@ describe("Helpers.documentationUrl", function () {
     )
   });
 
-  it("creates the correct URL for 'pub' components", function () {
-    expect(
-      Helpers.documentationUrl({
-        prefix: "pub-c",
-        name: "title"
-      })
-    ).toEqual(
-      "https://govuk-static.herokuapp.com/component-guide/title"
-    )
-  });
-
   it("creates the correct URL for 'gem' components", function () {
     setFixtures('<head><meta name="govuk:rendering-application" content="rendering_app"></head>');
     Helpers.substitutions =  {
@@ -207,32 +196,7 @@ describe("Helpers.documentationUrl", function () {
         name: "label"
       })
     ).toEqual(
-      "https://rendering_app.herokuapp.com/component-guide/label"
-    )
-  });
-
-  it("creates the correct URL for (deprecated) 'govuk' components", function () {
-    expect(
-      Helpers.documentationUrl({
-        prefix: "govuk",
-        name: "beta-label"
-      })
-    ).toEqual(
-      "https://govuk-static.herokuapp.com/component-guide/beta_label"
-    )
-  });
-
-  // Currently there are no components that are using the newer govuk-c prefix
-  // but we have assumed that it will follow the same component-name and
-  // component_url mismatch (dashes & underscores) that exists in govuk-static
-  it("creates the correct URL for 'govuk' components", function () {
-    expect(
-      Helpers.documentationUrl({
-        prefix: "govuk-c",
-        name: "component-name"
-      })
-    ).toEqual(
-      "https://govuk-static.herokuapp.com/component-guide/component_name"
+      "https://govuk-publishing-components.herokuapp.com/component-guide/label"
     )
   });
 });

--- a/src/highlight-component.js
+++ b/src/highlight-component.js
@@ -6,10 +6,10 @@ function HighlightComponent() {
   this.components = extractComponentsFromPage();
 
   function extractComponentsFromPage() {
-    return $('[class*="app-c"], [class*="pub-c"], [class*="gem-c"], [class*="govuk"]')
+    return $('[class*="app-c"], [class*="gem-c"], [class*="govuk"]')
       .toArray()
       .reduce(function(array, element) {
-        var blockRegex = /(app-c-|pub-c-|gem-c-|govuk-c-|govuk-)([^ _\n]*(?=[ \n]|$))/;
+        var blockRegex = /(app-c-|gem-c-|govuk-c-|govuk-)([^ _\n]*(?=[ \n]|$))/;
         var match = $(element).attr('class').match(blockRegex);
 
         if (match) {
@@ -117,9 +117,7 @@ var Helpers = {
     if (component.prefix.startsWith('app-c')) {
       return "https://" + this.appHostname() + ".herokuapp.com/component-guide/" + component.name
     } else if (component.prefix.startsWith('gem-c')) {
-      return "https://" + this.appHostname() + ".herokuapp.com/component-guide/" + component.name.replace(/-/g, '_');
-    } else {
-      return "https://govuk-static.herokuapp.com/component-guide/" + component.name.replace(/-/g, '_');
+      return "https://govuk-publishing-components.herokuapp.com/component-guide/" + component.name.replace(/-/g, '_');
     }
   },
 

--- a/src/highlight-component.js
+++ b/src/highlight-component.js
@@ -118,6 +118,8 @@ var Helpers = {
       return "https://" + this.appHostname() + ".herokuapp.com/component-guide/" + component.name
     } else if (component.prefix.startsWith('gem-c')) {
       return "https://govuk-publishing-components.herokuapp.com/component-guide/" + component.name.replace(/-/g, '_');
+    } else if (component.prefix.startsWith('govuk-')) {
+      return "https://design-system.service.gov.uk/components/" + component.name;
     }
   },
 

--- a/src/highlight-component.js
+++ b/src/highlight-component.js
@@ -9,7 +9,7 @@ function HighlightComponent() {
     return $('[class*="app-c"], [class*="gem-c"], [class*="govuk"]')
       .toArray()
       .reduce(function(array, element) {
-        var blockRegex = /(app-c-|gem-c-|govuk-c-|govuk-)([^ _\n]*(?=[ \n]|$))/;
+        var blockRegex = /(app-c-|gem-c-|govuk-)([^ _\n]*(?=[ \n]|$))/;
         var match = $(element).attr('class').match(blockRegex);
 
         if (match) {


### PR DESCRIPTION
This removes the highlighting of components in Static. All of the components have been moved to the gem now, so there won't be any components from Static to highlight.

Also adds speculative linking to the Design System. `govuk-` is the prefix for patterns from the GOV.UK Design System. We're not using any components from it at the moment, but might be soon.

https://trello.com/c/pU7YINt1