### PR TITLE
Remove highlighting for Design System components

### DIFF
--- a/spec/javascripts/highlight_component_spec.js
+++ b/spec/javascripts/highlight_component_spec.js
@@ -199,15 +199,4 @@ describe("Helpers.documentationUrl", function () {
       "https://govuk-publishing-components.herokuapp.com/component-guide/label"
     )
   });
-
-  it("creates the correct URL for Design System components", function () {
-    expect(
-      Helpers.documentationUrl({
-        prefix: "govuk-",
-        name: "error-message"
-      })
-    ).toEqual(
-      "https://design-system.service.gov.uk/components/error-message"
-    )
-  });
 });

--- a/src/highlight-component.js
+++ b/src/highlight-component.js
@@ -118,8 +118,6 @@ var Helpers = {
       return "https://" + this.appHostname() + ".herokuapp.com/component-guide/" + component.name
     } else if (component.prefix.startsWith('gem-c')) {
       return "https://govuk-publishing-components.herokuapp.com/component-guide/" + component.name.replace(/-/g, '_');
-    } else if (component.prefix.startsWith('govuk-')) {
-      return "https://design-system.service.gov.uk/components/" + component.name;
     }
   },
 


### PR DESCRIPTION
The gem can't differentiate global classes like `govuk-width-container` from components in the design system, so it highlights a lot of things incorrectly and links to non-existent pages on the design system site.

Removing this is not really a problem because we always wrap GOV.UK Frontend components in our own component.

https://trello.com/c/YWkUAjtN