### PR TITLE
Remove special casing for the homepage

### DIFF
--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -37,22 +37,6 @@ describe("PopupView.generateContentLinks", function () {
     )
   })
 
-  it("generates a subset of URIs for the root page", function () {
-    var links = Popup.generateContentLinks(
-      "https://www.gov.uk/",
-      "https://www.gov.uk",
-      "/",
-      PROD_ENV
-    )
-
-    var urls = pluck(links, 'url')
-
-    expect(urls).toEqual([
-      'https://www.gov.uk/',
-      'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/'
-    ])
-  })
-
   it("does not generate URIs for publishing apps (non-www pages)", function () {
     var links = Popup.generateContentLinks(
       "https://search-admin.publishing.service.gov.uk/queries",

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -18,15 +18,11 @@ Popup.generateContentLinks = function(location, origin, pathname, currentEnviron
 
   // If we're on the homepage there's not much to show.
   links.push({ name: "On GOV.UK", url: origin + path })
-
-  if (path != '/') {
-    links.push({ name: "Content item (JSON)", url: origin + "/api/content" + path })
-    links.push({ name: "Search data (JSON)", url: origin + "/api/search.json?filter_link=" + path })
-    links.push({ name: "Info page", url: origin + "/info" + path })
-    links.push({ name: "Draft (may not always work)", url: currentEnvironment.protocol + '://draft-origin.' + currentEnvironment.serviceDomain + path })
-    links.push({ name: "User feedback", url: currentEnvironment.protocol + '://support.' + currentEnvironment.serviceDomain + '/anonymous_feedback?path=' + path })
-  }
-
+  links.push({ name: "Content item (JSON)", url: origin + "/api/content" + path })
+  links.push({ name: "Search data (JSON)", url: origin + "/api/search.json?filter_link=" + path })
+  links.push({ name: "Info page", url: origin + "/info" + path })
+  links.push({ name: "Draft (may not always work)", url: currentEnvironment.protocol + '://draft-origin.' + currentEnvironment.serviceDomain + path })
+  links.push({ name: "User feedback", url: currentEnvironment.protocol + '://support.' + currentEnvironment.serviceDomain + '/anonymous_feedback?path=' + path })
   links.push({ name: "National Archives", url: "http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk" + path })
 
   var currentUrl = origin + path;


### PR DESCRIPTION
We use to have to exclude the homepage from most features because there wasn't an accessible content item for that page. This is now fixed, so we can show all of the links now.