### PR TITLE
Better linking to publishers

### DIFF
--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -18,7 +18,8 @@ describe("PopupView.generateContentLinks", function () {
       'https://www.gov.uk/info/browse/disabilities',
       'https://draft-origin.publishing.service.gov.uk/browse/disabilities',
       'https://support.publishing.service.gov.uk/anonymous_feedback?path=/browse/disabilities',
-      'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities'
+      'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities',
+      'https://content-data-admin.publishing.service.gov.uk/metrics/browse/disabilities'
     ])
   })
 
@@ -65,7 +66,8 @@ describe("PopupView.generateContentLinks", function () {
       'https://www.gov.uk/info/browse/disabilities',
       'https://draft-origin.publishing.service.gov.uk/browse/disabilities',
       'https://support.publishing.service.gov.uk/anonymous_feedback?path=/browse/disabilities',
-      'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities'
+      'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities',
+      'https://content-data-admin.publishing.service.gov.uk/metrics/browse/disabilities'
     ])
   })
 

--- a/spec/javascripts/external_links_spec.js
+++ b/spec/javascripts/external_links_spec.js
@@ -162,6 +162,21 @@ describe("Popup.generateExternalLinks", function () {
     })
   })
 
+  it("generates edit links for Content Publisher items", function () {
+    var contentItem = {
+      publishing_app: 'content-publisher',
+      content_id: '4d8568c4-67f2-48da-a578-5ac6f35b69b4',
+      locale: 'cy',
+    }
+
+    var links = Popup.generateExternalLinks(contentItem, PROD_ENV)
+
+    expect(links).toContain({
+      name: 'Edit in Content Publisher',
+      url: 'https://content-publisher.publishing.service.gov.uk/documents/4d8568c4-67f2-48da-a578-5ac6f35b69b4:cy'
+    })
+  })
+
   it("includes a link to content-tagger", function () {
     var contentItem = {
       content_id: '4d8568c4-67f2-48da-a578-5ac6f35b69b4'

--- a/spec/javascripts/external_links_spec.js
+++ b/spec/javascripts/external_links_spec.js
@@ -42,14 +42,14 @@ describe("Popup.generateExternalLinks", function () {
 
   it("generates the correct docs link when a publishing app does not match the repository name", function () {
     var contentItem = {
-      publishing_app: 'tariff'
+      publishing_app: 'smartanswers'
     }
 
     var links = Popup.generateExternalLinks(contentItem, PROD_ENV)
 
     expect(links).toContain({
-      name: 'Publishing app: tariff',
-      url: 'https://docs.publishing.service.gov.uk/apps/trade-tariff-backend.html'
+      name: 'Publishing app: smartanswers',
+      url: 'https://docs.publishing.service.gov.uk/apps/smart-answers.html'
     })
   })
 

--- a/spec/javascripts/external_links_spec.js
+++ b/spec/javascripts/external_links_spec.js
@@ -120,6 +120,20 @@ describe("Popup.generateExternalLinks", function () {
     })
   })
 
+  it("generates edit links for step by steps", function () {
+    var contentItem = {
+      content_id: '4d8568c4-67f2-48da-a578-5ac6f35b69b4',
+      document_type: 'step_by_step_nav'
+    }
+
+    var links = Popup.generateExternalLinks(contentItem, PROD_ENV)
+
+    expect(links).toContain({
+      name: 'Look up in collections-publisher',
+      url: 'https://collections-publisher.publishing.service.gov.uk/step-by-step-pages'
+    })
+  })
+
   it("generates edit links for mainstream items", function () {
     var contentItem = {
       content_id: '4d8568c4-67f2-48da-a578-5ac6f35b69b4',

--- a/spec/javascripts/external_links_spec.js
+++ b/spec/javascripts/external_links_spec.js
@@ -27,7 +27,7 @@ describe("Popup.generateExternalLinks", function () {
     })
   })
 
-  it("generates a link to the publishing app GitHub", function () {
+  it("generates a link to the publishing app in the docs", function () {
     var contentItem = {
       publishing_app: 'collections-publisher'
     }
@@ -40,7 +40,7 @@ describe("Popup.generateExternalLinks", function () {
     })
   })
 
-  it("generates the correct Github link when a publishing app does not match the repository name", function () {
+  it("generates the correct docs link when a publishing app does not match the repository name", function () {
     var contentItem = {
       publishing_app: 'tariff'
     }

--- a/spec/javascripts/external_links_spec.js
+++ b/spec/javascripts/external_links_spec.js
@@ -102,7 +102,7 @@ describe("Popup.generateExternalLinks", function () {
 
     expect(links).toContain({
       name: 'Edit in collections-publisher',
-      url: 'https://collections-publisher.publishing.service.gov.uk/topics/4d8568c4-67f2-48da-a578-5ac6f35b69b4'
+      url: 'https://collections-publisher.publishing.service.gov.uk/specialist-sector-pages/4d8568c4-67f2-48da-a578-5ac6f35b69b4'
     })
   })
 

--- a/spec/javascripts/external_links_spec.js
+++ b/spec/javascripts/external_links_spec.js
@@ -144,7 +144,7 @@ describe("Popup.generateExternalLinks", function () {
     var links = Popup.generateExternalLinks(contentItem, PROD_ENV)
 
     expect(links).toContain({
-      name: 'Go to Whitehall Publisher',
+      name: 'Edit in Whitehall Publisher',
       url: 'https://whitehall-admin.publishing.service.gov.uk/government/admin/by-content-id/4d8568c4-67f2-48da-a578-5ac6f35b69b4'
     })
   })

--- a/spec/javascripts/external_links_spec.js
+++ b/spec/javascripts/external_links_spec.js
@@ -151,14 +151,16 @@ describe("Popup.generateExternalLinks", function () {
 
   it("generates edit links for Specalist Publisher items", function () {
     var contentItem = {
-      publishing_app: 'specialist-publisher'
+      publishing_app: 'specialist-publisher',
+      content_id: '4dd888e6-e890-4498-9913-b89e4e5a0059',
+      document_type: 'aaib_report',
     }
 
     var links = Popup.generateExternalLinks(contentItem, PROD_ENV)
 
     expect(links).toContain({
-      name: 'Go to Specialist Publisher',
-      url: 'https://specialist-publisher.publishing.service.gov.uk/'
+      name: 'Edit in Specialist Publisher',
+      url: 'https://specialist-publisher.publishing.service.gov.uk/aaib-reports/4dd888e6-e890-4498-9913-b89e4e5a0059'
     })
   })
 

--- a/spec/javascripts/extract_path_spec.js
+++ b/spec/javascripts/extract_path_spec.js
@@ -64,4 +64,10 @@ describe("Popup.extractPath", function () {
 
     expect(path).toBe("/maternity-paternity-calculator")
   })
+
+  it("returns the path for the content data manager", function () {
+    var path = Popup.extractPath("https://content-data-admin.publishing.service.gov.uk/metrics/browse/disabilities", "/metrics/browse/disabilities")
+
+    expect(path).toBe("/browse/disabilities")
+  })
 })

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -10,7 +10,7 @@ Popup.generateContentLinks = function(location, origin, pathname, currentEnviron
   }
 
   // This is 'https://www.gov.uk' or 'https://www-origin.integration.publishing.service.gov.uk/', etc.
-  if (origin == 'http://webarchive.nationalarchives.gov.uk' || origin.match(/draft-origin/) || origin.match(/support/)) {
+  if (origin == 'http://webarchive.nationalarchives.gov.uk' || origin.match(/draft-origin/) || origin.match(/content-data-admin/) || origin.match(/support/)) {
     origin = "https://www.gov.uk"
   }
 
@@ -24,6 +24,7 @@ Popup.generateContentLinks = function(location, origin, pathname, currentEnviron
   links.push({ name: "Draft (may not always work)", url: currentEnvironment.protocol + '://draft-origin.' + currentEnvironment.serviceDomain + path })
   links.push({ name: "User feedback", url: currentEnvironment.protocol + '://support.' + currentEnvironment.serviceDomain + '/anonymous_feedback?path=' + path })
   links.push({ name: "National Archives", url: "http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk" + path })
+  links.push({ name: "Content data (beta)", url: currentEnvironment.protocol + '://content-data-admin.' + currentEnvironment.serviceDomain + '/metrics' + path })
 
   var currentUrl = origin + path;
 

--- a/src/popup/external_links.js
+++ b/src/popup/external_links.js
@@ -92,7 +92,7 @@ function generateEditLink(contentItem, env) {
     }
   } else if (contentItem.publishing_app == 'whitehall') {
     return {
-      name: 'Go to Whitehall Publisher',
+      name: 'Edit in Whitehall Publisher',
       url: env.protocol + '://whitehall-admin.' + env.serviceDomain + '/government/admin/by-content-id/' + contentItem.content_id,
     }
   } else if (contentItem.document_type == 'manual') {

--- a/src/popup/external_links.js
+++ b/src/popup/external_links.js
@@ -70,6 +70,11 @@ function generateEditLink(contentItem, env) {
       name: 'Edit in collections-publisher',
       url: env.protocol + '://collections-publisher.' + env.serviceDomain + '/topics/' + contentItem.content_id,
     }
+  } else if (contentItem.document_type == 'step_by_step_nav') {
+    return {
+      name: 'Look up in collections-publisher',
+      url: env.protocol + '://collections-publisher.' + env.serviceDomain + '/step-by-step-pages',
+    }
   } else if (contentItem.document_type == 'mainstream_browse_page') {
     return {
       name: 'Edit in collections-publisher',

--- a/src/popup/external_links.js
+++ b/src/popup/external_links.js
@@ -68,7 +68,7 @@ function generateEditLink(contentItem, env) {
   if (contentItem.document_type == 'topic') {
     return {
       name: 'Edit in collections-publisher',
-      url: env.protocol + '://collections-publisher.' + env.serviceDomain + '/topics/' + contentItem.content_id,
+      url: env.protocol + '://collections-publisher.' + env.serviceDomain + '/specialist-sector-pages/' + contentItem.content_id,
     }
   } else if (contentItem.document_type == 'step_by_step_nav') {
     return {

--- a/src/popup/external_links.js
+++ b/src/popup/external_links.js
@@ -101,10 +101,9 @@ function generateEditLink(contentItem, env) {
       url: env.protocol + '://manuals-publisher.' + env.serviceDomain + '/manuals/' + contentItem.content_id,
     }
   } else if (contentItem.publishing_app == 'specialist-publisher') {
-    // TODO: link directly to the specialist document edit page
     return {
-      name: 'Go to Specialist Publisher',
-      url: env.protocol + '://specialist-publisher.' + env.serviceDomain + '/',
+      name: 'Edit in Specialist Publisher',
+      url: env.protocol + '://specialist-publisher.' + env.serviceDomain + '/' + contentItem.document_type.replace("_", "-") + 's/' + contentItem.content_id,
     }
   }
 }

--- a/src/popup/external_links.js
+++ b/src/popup/external_links.js
@@ -88,6 +88,11 @@ function generateEditLink(contentItem, env) {
       name: 'Look up in Mainstream Publisher',
       url: env.protocol + '://publisher.' + env.serviceDomain + '/?list=published&string_filter=' + contentItem.base_path.substring(1) + '&user_filter=all',
     }
+  } else if (contentItem.publishing_app == 'content-publisher') {
+    return {
+      name: 'Edit in Content Publisher',
+      url: env.protocol + '://content-publisher.' + env.serviceDomain + '/documents/' + contentItem.content_id + ':' + contentItem.locale,
+    }
   } else if (contentItem.publishing_app == 'whitehall') {
     return {
       name: 'Go to Whitehall Publisher',

--- a/src/popup/external_links.js
+++ b/src/popup/external_links.js
@@ -8,7 +8,6 @@ Popup.generateExternalLinks = function(contentItem, env) {
   function publishingAppNameToRepo(appName) {
     var APP_NAMES_TO_REPOS = {
       smartanswers: 'smart-answers',
-      tariff: 'trade-tariff-backend'
     };
 
     return APP_NAMES_TO_REPOS[appName] || appName;
@@ -19,9 +18,7 @@ Popup.generateExternalLinks = function(contentItem, env) {
   function renderingAppNameToRepo(appName) {
     var APP_NAMES_TO_REPOS = {
       smartanswers: 'smart-answers',
-      designprinciples: 'design-principles',
       'whitehall-frontend': 'whitehall',
-      tariff: 'trade-tariff-frontend'
     };
 
     return APP_NAMES_TO_REPOS[appName] || appName;

--- a/src/popup/extract_path.js
+++ b/src/popup/extract_path.js
@@ -11,6 +11,9 @@ Popup.extractPath = function(location, pathname, renderingApplication) {
   else if (location.match(/anonymous_feedback/)) {
     extractedPath = extractQueryParameter(location, 'path');
   }
+  else if (location.match(/content-data-admin/)) {
+    extractedPath = pathname.replace('metrics/', '');;
+  }
   else if (location.match(/nationalarchives.gov.uk/)) {
     extractedPath = pathname.split('https://www.gov.uk')[1];
   }

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -68,6 +68,8 @@ var Popup = Popup || {};
       $.getJSON(contentStore.url, function(contentStoreData) {
         view.externalLinks = Popup.generateExternalLinks(contentStoreData, view.currentEnvironment);
         renderView(view, location);
+      }).fail(function () {
+        renderView(view, location);
       })
     } else {
       renderView(view, location);


### PR DESCRIPTION
This PR:

- Adds a link to [content publisher](https://github.com/alphagov/content-publisher) for pages published by that app (cc @kevindew)
- Adds a link to [content data admin](https://github.com/alphagov/content-data-admin) for all pages (cc @pmanrubia)
- Fixes the link to topics (https://github.com/alphagov/govuk-browser-extension/issues/114)
- Links to collections publisher for step by steps
- Deeplinks to Specialist Publisher documents
- Few small fixes
