### PR TITLE
Change origin URLs to CDN

### DIFF
--- a/spec/javascripts/environment_spec.js
+++ b/spec/javascripts/environment_spec.js
@@ -14,26 +14,9 @@ describe("Popup.environment", function() {
 
     expect(urls).toEqual([
       'https://www.gov.uk/browse/disabilities?foo=bar',
+      'https://www.staging.publishing.service.gov.uk/browse/disabilities?foo=bar',
+      'https://www.integration.publishing.service.gov.uk/browse/disabilities?foo=bar',
       'http://www.dev.gov.uk/browse/disabilities?foo=bar',
-      'https://www-origin.staging.publishing.service.gov.uk/browse/disabilities?foo=bar',
-      'https://www-origin.integration.publishing.service.gov.uk/browse/disabilities?foo=bar',
-      'https://www-origin.publishing.service.gov.uk/browse/disabilities?foo=bar',
-    ])
-  })
-
-  it("returns the correct variants for production origin", function() {
-    var envs = createEnvironmentForUrl(
-      "https://www-origin.production.publishing.service.gov.uk/browse/disabilities?foo=bar"
-    )
-
-    var urls = pluck(envs, 'url');
-
-    expect(urls).toEqual([
-      'https://www.gov.uk/browse/disabilities?foo=bar',
-      'http://www.dev.gov.uk/browse/disabilities?foo=bar',
-      'https://www-origin.staging.publishing.service.gov.uk/browse/disabilities?foo=bar',
-      'https://www-origin.integration.publishing.service.gov.uk/browse/disabilities?foo=bar',
-      'https://www-origin.publishing.service.gov.uk/browse/disabilities?foo=bar',
     ])
   })
 
@@ -46,14 +29,13 @@ describe("Popup.environment", function() {
 
     expect(urls).toEqual([
       'https://www.gov.uk/browse/disabilities?foo=bar',
+      'https://www.staging.publishing.service.gov.uk/browse/disabilities?foo=bar',
+      'https://www.integration.publishing.service.gov.uk/browse/disabilities?foo=bar',
       'http://www.dev.gov.uk/browse/disabilities?foo=bar',
-      'https://www-origin.staging.publishing.service.gov.uk/browse/disabilities?foo=bar',
-      'https://www-origin.integration.publishing.service.gov.uk/browse/disabilities?foo=bar',
-      'https://www-origin.publishing.service.gov.uk/browse/disabilities?foo=bar',
     ])
   })
 
-  it("shows production, dev, staging and integration on publisher-apps", function() {
+  it("shows production, staging, integration and development on publisher-apps", function() {
     var envs = createEnvironmentForUrl(
       "https://signon.publishing.service.gov.uk/"
     )
@@ -61,7 +43,7 @@ describe("Popup.environment", function() {
     var environmentNames = pluck(envs, 'name')
 
     expect(environmentNames).toEqual([
-      'Production', 'Development', 'Staging', 'Integration'
+      'Production', 'Staging', 'Integration', 'Development'
     ])
   })
 

--- a/src/popup/environment.js
+++ b/src/popup/environment.js
@@ -29,41 +29,30 @@ Popup.environment = function(location, host, origin) {
       host: "https://www.gov.uk"
     },
     {
-      name: "Development",
-      protocol: "http",
-      serviceDomain: "dev.gov.uk",
-      host: "http://www.dev.gov.uk"
-    },
-    {
       name: "Staging",
       protocol: "https",
       serviceDomain: "staging.publishing.service.gov.uk",
-      host: "https://www-origin.staging.publishing.service.gov.uk"
+      host: "https://www.staging.publishing.service.gov.uk"
     },
     {
       name: "Integration",
       protocol: "https",
       serviceDomain: "integration.publishing.service.gov.uk",
-      host: "https://www-origin.integration.publishing.service.gov.uk"
+      host: "https://www.integration.publishing.service.gov.uk"
+    },
+    {
+      name: "Development",
+      protocol: "http",
+      serviceDomain: "dev.gov.uk",
+      host: "http://www.dev.gov.uk"
     }
   ]
-
-  var ORIGIN = {
-    name: "Prod (origin)",
-    protocol: "https",
-    serviceDomain: "publishing.service.gov.uk",
-    host: "https://www-origin.publishing.service.gov.uk"
-  };
 
   var application = host.split('.')[0],
   inFrontend = application.match(/www/),
   environments = ENVIRONMENTS;
 
   var currentEnvironment;
-
-  if (inFrontend) {
-    environments.push(ORIGIN);
-  }
 
   var allEnvironments = environments.map(function (env) {
     if (inFrontend) {


### PR DESCRIPTION
This commit changes the staging and integration URLs to point to the CDN rather than origin. It also removes the production origin link, and moves development to the end of the list.