### PR TITLE
Update release instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-## GOV.UK Toolkit for Chrome and Firefox
+# GOV.UK Toolkit for Chrome and Firefox
 
 Allows easy switching between the different GOV.UK environments and content representations. Inspired by the [govuk-bookmarklets](https://github.com/dsingleton/govuk-bookmarklets).
 
 ![Screenshot](docs/screenshots.gif)
 
-### Installation
+## Installation
 
 The extension is [downloadable on the Chrome web store](https://chrome.google.com/webstore/detail/govuk-toolkit/dclfaikcemljbaoagjnedmlppnbiljen) and [AMO for Firefox](https://addons.mozilla.org/en-GB/firefox/addon/govuk-toolkit/).
 
 If you don't want to install from your browser's web store for security reasons, you can install a local non-self updating copy.
 
-#### For Chrome:
+### For Chrome:
 
 1. [Download the source from GitHub](https://github.com/alphagov/govuk-browser-extension/archive/master.zip) and unzip.
 2. Visit [chrome://extensions](chrome://extensions) in your browser.
@@ -21,7 +21,7 @@ If you don't want to install from your browser's web store for security reasons,
 
 Source: [Getting Started: Building a Chrome Extension](https://developer.chrome.com/extensions/getstarted#unpacked).
 
-#### For Firefox:
+### For Firefox:
 
 Extensions installed using the following instructions are only active while Firefox
 is open and are removed on exit. Permanently-active extensions can be only be
@@ -35,7 +35,7 @@ installed from packages signed by Mozilla.
 
 Source: [Temporary installation in Firefox](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/Temporary_Installation_in_Firefox).
 
-### Running the tests
+## Running the tests
 
 In development, it's easiest to run:
 
@@ -51,12 +51,13 @@ You can also run the Jasmine test suite in slower "headless" mode with:
 $ bundle exec rake jasmine:ci
 ```
 
-### Releasing the extension
+## Releasing the extension
 
 1. Update the version in `manifest.json`
 2. Run `rake build`
-3. Upload newly created package in `/build` to the [Chrome web store](https://chrome.google.com/webstore/developer/edit/dclfaikcemljbaoagjnedmlppnbiljen) (you will need to have been added to the [govukdevelopers](govukdevelopers@googlegroups.com) google group) and [AMO](https://addons.mozilla.org/en-US/developers/addon/govuk-toolkit/versions/submit/) (account details in the [2nd line password store](https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/firefox))
-4. Create a [new release on GitHub](https://github.com/alphagov/govuk-browser-extension/releases/new)
+3. Create a Pull Request with the new package committed
+4. Upload newly created package in `/build` to the [Chrome web store](https://chrome.google.com/webstore/developer/edit/dclfaikcemljbaoagjnedmlppnbiljen). You will need to have been added to the [govukdevelopers google group](https://groups.google.com/forum/#!forum/govukdevelopers) (at the time of writing, @tijmenb, @andysellick, and @alex-ju).
+5. Upload newly created package in `/build` to [Firefox Add-ons](https://addons.mozilla.org/en-US/developers/addon/govuk-toolkit/versions/submit/). Account details in the [2nd line password store](https://github.com/alphagov/govuk-secrets/tree/master/pass/2ndline/firefox).
 
 ### License
 


### PR DESCRIPTION
- No longer require releases on GitHub (it's hasn't been happening anyway)
- Note that you have to raise a PR
- Make clearer what you need to release the Chrome extension
- Tweak headings