### PR TITLE
Update name of the link to Content Data

### DIFF
--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -24,7 +24,7 @@ Popup.generateContentLinks = function(location, origin, pathname, currentEnviron
   links.push({ name: "Draft (may not always work)", url: currentEnvironment.protocol + '://draft-origin.' + currentEnvironment.serviceDomain + path })
   links.push({ name: "User feedback", url: currentEnvironment.protocol + '://support.' + currentEnvironment.serviceDomain + '/anonymous_feedback?path=' + path })
   links.push({ name: "National Archives", url: "http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk" + path })
-  links.push({ name: "Content data (beta)", url: currentEnvironment.protocol + '://content-data-admin.' + currentEnvironment.serviceDomain + '/metrics' + path })
+  links.push({ name: "View data about page", url: currentEnvironment.protocol + '://content-data-admin.' + currentEnvironment.serviceDomain + '/metrics' + path })
 
   var currentUrl = origin + path;
 


### PR DESCRIPTION
Changing the name of the link to describe better what will happen next. This matches the copy in the link that is used in Whitehall publisher.