### PR TITLE
Cater for multiple underscores in doc types

### DIFF
--- a/spec/javascripts/external_links_spec.js
+++ b/spec/javascripts/external_links_spec.js
@@ -167,14 +167,14 @@ describe("Popup.generateExternalLinks", function () {
     var contentItem = {
       publishing_app: 'specialist-publisher',
       content_id: '4dd888e6-e890-4498-9913-b89e4e5a0059',
-      document_type: 'aaib_report',
+      document_type: 'business_finance_support_scheme',
     }
 
     var links = Popup.generateExternalLinks(contentItem, PROD_ENV)
 
     expect(links).toContain({
       name: 'Edit in Specialist Publisher',
-      url: 'https://specialist-publisher.publishing.service.gov.uk/aaib-reports/4dd888e6-e890-4498-9913-b89e4e5a0059'
+      url: 'https://specialist-publisher.publishing.service.gov.uk/business-finance-support-schemes/4dd888e6-e890-4498-9913-b89e4e5a0059'
     })
   })
 

--- a/src/popup/external_links.js
+++ b/src/popup/external_links.js
@@ -108,7 +108,7 @@ function generateEditLink(contentItem, env) {
   } else if (contentItem.publishing_app == 'specialist-publisher') {
     return {
       name: 'Edit in Specialist Publisher',
-      url: env.protocol + '://specialist-publisher.' + env.serviceDomain + '/' + contentItem.document_type.replace("_", "-") + 's/' + contentItem.content_id,
+      url: env.protocol + '://specialist-publisher.' + env.serviceDomain + '/' + contentItem.document_type.replace(/_/g, "-") + 's/' + contentItem.content_id,
     }
   }
 }


### PR DESCRIPTION
The javascript replace function only replaces the first instance of a string by default.  By using a global regex, we can correctly convert document types like 'business_finance_support_scheme' to the partial slug 'business-finance-support-schemes'.

The error can be seen if you try to use the GOV.UK browser extension to "Edit in Specialist Publisher" any pages like https://www.gov.uk/business-finance-support/business-cash-advance-uk