### PR TITLE
Add link to structured data testing tool

### DIFF
--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -19,7 +19,8 @@ describe("PopupView.generateContentLinks", function () {
       'https://draft-origin.publishing.service.gov.uk/browse/disabilities',
       'https://support.publishing.service.gov.uk/anonymous_feedback?path=/browse/disabilities',
       'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities',
-      'https://content-data-admin.publishing.service.gov.uk/metrics/browse/disabilities'
+      'https://content-data-admin.publishing.service.gov.uk/metrics/browse/disabilities',
+      'https://search.google.com/structured-data/testing-tool/u/0/#url=https://www.gov.uk/browse/disabilities',
     ])
   })
 
@@ -67,7 +68,8 @@ describe("PopupView.generateContentLinks", function () {
       'https://draft-origin.publishing.service.gov.uk/browse/disabilities',
       'https://support.publishing.service.gov.uk/anonymous_feedback?path=/browse/disabilities',
       'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities',
-      'https://content-data-admin.publishing.service.gov.uk/metrics/browse/disabilities'
+      'https://content-data-admin.publishing.service.gov.uk/metrics/browse/disabilities',
+      'https://search.google.com/structured-data/testing-tool/u/0/#url=https://www.gov.uk/browse/disabilities'
     ])
   })
 

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -25,6 +25,7 @@ Popup.generateContentLinks = function(location, origin, pathname, currentEnviron
   links.push({ name: "User feedback", url: currentEnvironment.protocol + '://support.' + currentEnvironment.serviceDomain + '/anonymous_feedback?path=' + path })
   links.push({ name: "National Archives", url: "http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk" + path })
   links.push({ name: "View data about page", url: currentEnvironment.protocol + '://content-data-admin.' + currentEnvironment.serviceDomain + '/metrics' + path })
+  links.push({ name: "View structured data", url: "https://search.google.com/structured-data/testing-tool/u/0/#url=https://www.gov.uk" + path })
 
   var currentUrl = origin + path;
 


### PR DESCRIPTION
This allows easy checking of what structured data is on a page, and whether it passes Google's validity checks.

Pages inspected via URL need to be publicly accessible, so I've limited this to production URLs.  

You can also submit snippets of HTML on the testing tool if you want to test non-live pages, but that's out of scope for this.

On GOV.UK we currently implement:
- Breadcrumb (on most pages)
- Article (on most pages)
- NewsArticle (on news pages)
- GovernmentOrganization (on organisation pages)
- HowTo (on step by step pages)
- SearchResultsPage (on search pages)
- FaqPage (on answers and guides)