### PR TITLE
Adds contextual info when transforming links based on environment

### DIFF
--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -1,5 +1,6 @@
 describe("PopupView.generateContentLinks", function () {
   var PROD_ENV = { protocol: 'https', serviceDomain: 'publishing.service.gov.uk' }
+  var DRAFT_ENV = { protocol: 'https', serviceDomain: 'https://draft-origin.integration.publishing.service.gov.uk' }
 
   it("returns the correct URIs", function () {
     var links = Popup.generateContentLinks(
@@ -102,5 +103,19 @@ describe("PopupView.generateContentLinks", function () {
     var urls = pluck(links, 'url')
 
     expect(urls).not.toContain("https://www.gov.uk/smart-answer.txt")
+  })
+
+  it("provides additional context when presenting links on a draft-origin URL", function () {
+    var links = Popup.generateContentLinks(
+      "https://draft-origin.integration.publishing.service.gov.uk/apply-for-and-manage-a-gov-uk-domain-name",
+      "https://draft-origin.integration.publishing.service.gov.uk",
+      "/apply-for-and-manage-a-gov-uk-domain-name",
+      DRAFT_ENV,
+      "collections"
+    )
+
+    var linkTexts = pluck(links, 'name')
+
+    expect(linkTexts).toContain("Content item (JSON) (GOV.UK only: not available on draft stack)")
   })
 })

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -10,22 +10,24 @@ Popup.generateContentLinks = function(location, origin, pathname, currentEnviron
   }
 
   // This is 'https://www.gov.uk' or 'https://www-origin.integration.publishing.service.gov.uk/', etc.
+  var disclaimer = ""
   if (origin == 'http://webarchive.nationalarchives.gov.uk' || origin.match(/draft-origin/) || origin.match(/content-data-admin/) || origin.match(/support/)) {
     origin = "https://www.gov.uk"
+    disclaimer = " (GOV.UK only: not available on draft stack)"
   }
 
   var links = []
 
   // If we're on the homepage there's not much to show.
   links.push({ name: "On GOV.UK", url: origin + path })
-  links.push({ name: "Content item (JSON)", url: origin + "/api/content" + path })
-  links.push({ name: "Search data (JSON)", url: origin + "/api/search.json?filter_link=" + path })
-  links.push({ name: "Info page", url: origin + "/info" + path })
+  links.push({ name: "Content item (JSON)" + disclaimer, url: origin + "/api/content" + path })
+  links.push({ name: "Search data (JSON)" + disclaimer, url: origin + "/api/search.json?filter_link=" + path })
+  links.push({ name: "Info page" + disclaimer, url: origin + "/info" + path })
   links.push({ name: "Draft (may not always work)", url: currentEnvironment.protocol + '://draft-origin.' + currentEnvironment.serviceDomain + path })
   links.push({ name: "User feedback", url: currentEnvironment.protocol + '://support.' + currentEnvironment.serviceDomain + '/anonymous_feedback?path=' + path })
   links.push({ name: "National Archives", url: "http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk" + path })
   links.push({ name: "View data about page", url: currentEnvironment.protocol + '://content-data-admin.' + currentEnvironment.serviceDomain + '/metrics' + path })
-  links.push({ name: "View structured data", url: "https://search.google.com/structured-data/testing-tool/u/0/#url=https://www.gov.uk" + path })
+  links.push({ name: "View structured data" + disclaimer, url: "https://search.google.com/structured-data/testing-tool/u/0/#url=https://www.gov.uk" + path })
 
   var currentUrl = origin + path;
 


### PR DESCRIPTION
I was previewing a piece of content on the draft stack when I used the
extension to view the content item. I was confused that this took me
to the live content item on GOV.UK, rather than the content item on
integration that I wanted.

Then I realised (when I navigated to the integration content item) that
it didn't contain the content I expected - and that's because the content
was still in draft, not published. I now understood why the extension
was unable to link me to the content store environment I wanted - it
doesn't exist.

Have now added some contextual information only when we override the
origin we redirect people to.

Before:

![Screen Shot 2019-10-18 at 13 58 21](https://user-images.githubusercontent.com/5111927/67096177-70781700-f1af-11e9-8b26-582f9b957c80.png)

After

![Screen Shot 2019-10-18 at 13 31 47](https://user-images.githubusercontent.com/5111927/67095975-1414f780-f1af-11e9-916e-230cde85e773.png)
