### PR TITLE
Fixes link to content item (JSON) when viewing draft content

### DIFF
--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -1,5 +1,6 @@
 describe("PopupView.generateContentLinks", function () {
-  var PROD_ENV = { protocol: 'https', serviceDomain: 'publishing.service.gov.uk' }
+  var PROD_ENV = { protocol: 'https', serviceDomain: 'publishing.service.gov.uk', origin: 'https://www.gov.uk' }
+  var DRAFT_PROD_ENV = { protocol: 'https', serviceDomain: 'publishing.service.gov.uk', origin: 'https://draft-origin.publishing.service.gov.uk' }
 
   it("returns the correct URIs", function () {
     var links = Popup.generateContentLinks(
@@ -102,5 +103,21 @@ describe("PopupView.generateContentLinks", function () {
     var urls = pluck(links, 'url')
 
     expect(urls).not.toContain("https://www.gov.uk/smart-answer.txt")
+  })
+
+  it("generates correct link for content API on draft stack", function () {
+    var links = Popup.generateContentLinks(
+      "https://draft-origin.publishing.service.gov.uk/apply-for-and-manage-a-gov-uk-domain-name",
+      "https://draft-origin.publishing.service.gov.uk",
+      "/apply-for-and-manage-a-gov-uk-domain-name",
+      DRAFT_PROD_ENV,
+      "collections"
+    )
+
+    expect(links[1]).toEqual({
+      name: "Content item (JSON)",
+      url:  "https://draft-origin.publishing.service.gov.uk/api/content/apply-for-and-manage-a-gov-uk-domain-name",
+      class: ""
+    })
   })
 })

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -18,7 +18,7 @@ Popup.generateContentLinks = function(location, origin, pathname, currentEnviron
 
   // If we're on the homepage there's not much to show.
   links.push({ name: "On GOV.UK", url: origin + path })
-  links.push({ name: "Content item (JSON)", url: origin + "/api/content" + path })
+  links.push({ name: "Content item (JSON)", url: currentEnvironment.origin + "/api/content" + path })
   links.push({ name: "Search data (JSON)", url: origin + "/api/search.json?filter_link=" + path })
   links.push({ name: "Info page", url: origin + "/info" + path })
   links.push({ name: "Draft (may not always work)", url: currentEnvironment.protocol + '://draft-origin.' + currentEnvironment.serviceDomain + path })

--- a/src/popup/environment.js
+++ b/src/popup/environment.js
@@ -26,25 +26,29 @@ Popup.environment = function(location, host, origin) {
       name: "Production",
       protocol: "https",
       serviceDomain: "publishing.service.gov.uk",
-      host: "https://www.gov.uk"
+      host: "https://www.gov.uk",
+      origin: origin
     },
     {
       name: "Staging",
       protocol: "https",
       serviceDomain: "staging.publishing.service.gov.uk",
-      host: "https://www.staging.publishing.service.gov.uk"
+      host: "https://www.staging.publishing.service.gov.uk",
+      origin: origin
     },
     {
       name: "Integration",
       protocol: "https",
       serviceDomain: "integration.publishing.service.gov.uk",
-      host: "https://www.integration.publishing.service.gov.uk"
+      host: "https://www.integration.publishing.service.gov.uk",
+      origin: origin
     },
     {
       name: "Development",
       protocol: "http",
       serviceDomain: "dev.gov.uk",
-      host: "http://www.dev.gov.uk"
+      host: "http://www.dev.gov.uk",
+      origin: origin
     }
   ]
 


### PR DESCRIPTION
I was previewing a piece of content on the draft stack when I used the
extension to view the content item. I was confused that this took me
to the live content item on GOV.UK, rather than the content item on
integration that I wanted.

Now if you're on:
https://draft-origin.integration.publishing.service.gov.uk/guidance/check-if-your-organisation-can-get-a-govuk-domain-name

And you click 'Content item (JSON)'

Instead of https://www.gov.uk/api/content/guidance/check-if-your-organisation-can-get-a-govuk-domain-name

You're taken to:
https://draft-origin.integration.publishing.service.gov.uk/api/content/guidance/check-if-your-organisation-can-get-a-govuk-domain-name