### PR TITLE
Enable GOVUK Browser extension on GOVUK Accounts

### DIFF
--- a/spec/javascripts/environment_spec.js
+++ b/spec/javascripts/environment_spec.js
@@ -47,6 +47,18 @@ describe("Popup.environment", function() {
     ])
   })
 
+  it("Only shows production, staging and development on the GOVUK Account", function() {
+    var envs = createEnvironmentForUrl(
+      "https://www.account.publishing.service.gov.uk/"
+    )
+
+    var environmentNames = pluck(envs, 'name')
+
+    expect(environmentNames).toEqual([
+      'Production', 'Staging', 'Development'
+    ])
+  })
+
   it("correctly identifies the current environment", function() {
     var forProd = createEnvironmentForUrl(
       "https://www.gov.uk/browse/disabilities?foo=bar"

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -5,7 +5,8 @@ Popup.generateContentLinks = function(location, origin, pathname, currentEnviron
   var path = Popup.extractPath(location, pathname, renderingApplication);
 
   // If no path can be found (which means we're probably in a publishing app)
-  if (!path) {
+  // Similarly if we're on GOVUK account, not many of the links are relevant
+  if (!path || origin.match(/www.account/)) {
     return [];
   }
 


### PR DESCRIPTION
Currently the browser extension does not work on any of the GOVUK Account pages. 
When you click the extension icon, an unhelpful **"Loading..."** message appears and none of the features seem to be available.
<img width="1217" alt="Screenshot 2021-04-21 at 09 32 49" src="https://user-images.githubusercontent.com/7116819/115749801-64b27580-a38f-11eb-867a-e2003b9032bd.png">


Implement the changes necessary to support use of the browser extension on GOVUK Accounts, so that features such as "Design mode" or "highlight components" can be used by colleagues working on the service.


-----
https://trello.com/c/d0gHnIxQ/726-make-govuk-browser-extension-work-on-the-account-manager-pages