### PR TITLE
Remove 'SmartAnswers: Display GovSpeak' option

### DIFF
--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -85,24 +85,7 @@ describe("PopupView.generateContentLinks", function () {
 
     var urls = pluck(links, 'url')
 
-    expect(urls).toContain(
-      "https://www.gov.uk/smart-answer/y/question-1.txt",
-      "https://www.gov.uk/smart-answer/y/visualise"
-    )
-  })
-
-  it("does not generate a markdown link for landing pages", function () {
-    var links = Popup.generateContentLinks(
-      "https://www.gov.uk/smart-answer",
-      "https://www.gov.uk",
-      "/smart-answer",
-      PROD_ENV,
-      "smartanswers"
-    )
-
-    var urls = pluck(links, 'url')
-
-    expect(urls).not.toContain("https://www.gov.uk/smart-answer.txt")
+    expect(urls).toContain("https://www.gov.uk/smart-answer/y/visualise")
   })
 
   it("generates correct link for content API on draft stack", function () {

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -31,10 +31,6 @@ Popup.generateContentLinks = function(location, origin, pathname, currentEnviron
   var currentUrl = origin + path;
 
   if (renderingApplication == "smartanswers") {
-    if (currentUrl.match(/\/y\/?.*$/)) {
-      links.push({ name: "SmartAnswers: Display GovSpeak", url: currentUrl + ".txt"})
-    }
-
     links.push({ name: "SmartAnswers: Visualise", url: currentUrl.replace(/\/y.*$/, "") + "/y/visualise" })
   }
 


### PR DESCRIPTION
The govuk browser extension has a “Display Govspeak” menu option that shows when you visit a smart answer. But it doesn’t work, and it looks like it relies on a feature of SmartAnswers that was removed a while ago. The content team don’t use it, so it makes sense to remove it completely.

Fixes: https://github.com/alphagov/govuk-browser-extension/issues/163

Trello card: https://trello.com/c/lcZjfxq8/1838-remove-unused-display-govspeak-option-from-govuk-browser-extension