### PR TITLE
Ensure that smart answer content items have base_paths

### DIFF
--- a/spec/javascripts/external_links_spec.js
+++ b/spec/javascripts/external_links_spec.js
@@ -16,7 +16,8 @@ describe("Popup.generateExternalLinks", function () {
 
   it("generates a Github link when the rendering app does not match the repository name", function () {
     var contentItem = {
-      rendering_app: 'smartanswers'
+      rendering_app: 'smartanswers',
+      base_path: '/my-smart-answer'
     }
 
     var links = Popup.generateExternalLinks(contentItem, PROD_ENV)
@@ -42,7 +43,8 @@ describe("Popup.generateExternalLinks", function () {
 
   it("generates the correct docs link when a publishing app does not match the repository name", function () {
     var contentItem = {
-      publishing_app: 'smartanswers'
+      publishing_app: 'smartanswers',
+      base_path: '/my-smart-answer'
     }
 
     var links = Popup.generateExternalLinks(contentItem, PROD_ENV)


### PR DESCRIPTION
- these are now needed in the generateExternalLinks method, which makes GH links from the base_path for smart answers.