### PR TITLE
Use the canonical hostname for Content Data app.

### DIFF
--- a/spec/javascripts/content_links_spec.js
+++ b/spec/javascripts/content_links_spec.js
@@ -20,7 +20,7 @@ describe("PopupView.generateContentLinks", function () {
       'https://draft-origin.publishing.service.gov.uk/browse/disabilities',
       'https://support.publishing.service.gov.uk/anonymous_feedback?path=/browse/disabilities',
       'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities',
-      'https://content-data-admin.publishing.service.gov.uk/metrics/browse/disabilities',
+      'https://content-data.publishing.service.gov.uk/metrics/browse/disabilities',
       'https://search.google.com/structured-data/testing-tool/u/0/#url=https://www.gov.uk/browse/disabilities',
     ])
   })
@@ -69,7 +69,7 @@ describe("PopupView.generateContentLinks", function () {
       'https://draft-origin.publishing.service.gov.uk/browse/disabilities',
       'https://support.publishing.service.gov.uk/anonymous_feedback?path=/browse/disabilities',
       'http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk/browse/disabilities',
-      'https://content-data-admin.publishing.service.gov.uk/metrics/browse/disabilities',
+      'https://content-data.publishing.service.gov.uk/metrics/browse/disabilities',
       'https://search.google.com/structured-data/testing-tool/u/0/#url=https://www.gov.uk/browse/disabilities'
     ])
   })

--- a/spec/javascripts/extract_path_spec.js
+++ b/spec/javascripts/extract_path_spec.js
@@ -66,7 +66,7 @@ describe("Popup.extractPath", function () {
   })
 
   it("returns the path for the content data manager", function () {
-    var path = Popup.extractPath("https://content-data-admin.publishing.service.gov.uk/metrics/browse/disabilities", "/metrics/browse/disabilities")
+    var path = Popup.extractPath("https://content-data.publishing.service.gov.uk/metrics/browse/disabilities", "/metrics/browse/disabilities")
 
     expect(path).toBe("/browse/disabilities")
   })

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "name": "GOV.UK Browser Extension",
   "description": "Switch between GOV.UK environments and content",
   "homepage_url": "https://github.com/alphagov/govuk-browser-extension",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "content_scripts": [
     {
       "matches": ["https://*.gov.uk/*"],

--- a/src/popup/content_links.js
+++ b/src/popup/content_links.js
@@ -11,7 +11,7 @@ Popup.generateContentLinks = function(location, origin, pathname, currentEnviron
   }
 
   // This is 'https://www.gov.uk' or 'https://www-origin.integration.publishing.service.gov.uk/', etc.
-  if (origin == 'http://webarchive.nationalarchives.gov.uk' || origin.match(/draft-origin/) || origin.match(/content-data-admin/) || origin.match(/support/)) {
+  if (origin == 'http://webarchive.nationalarchives.gov.uk' || origin.match(/draft-origin/) || origin.match(/content-data/) || origin.match(/support/)) {
     origin = "https://www.gov.uk"
   }
 
@@ -25,7 +25,7 @@ Popup.generateContentLinks = function(location, origin, pathname, currentEnviron
   links.push({ name: "Draft (may not always work)", url: currentEnvironment.protocol + '://draft-origin.' + currentEnvironment.serviceDomain + path })
   links.push({ name: "User feedback", url: currentEnvironment.protocol + '://support.' + currentEnvironment.serviceDomain + '/anonymous_feedback?path=' + path })
   links.push({ name: "National Archives", url: "http://webarchive.nationalarchives.gov.uk/*/https://www.gov.uk" + path })
-  links.push({ name: "View data about page on Content Data", url: currentEnvironment.protocol + '://content-data-admin.' + currentEnvironment.serviceDomain + '/metrics' + path })
+  links.push({ name: "View data about page on Content Data", url: currentEnvironment.protocol + '://content-data.' + currentEnvironment.serviceDomain + '/metrics' + path })
   links.push({ name: "View structured data", url: "https://search.google.com/structured-data/testing-tool/u/0/#url=https://www.gov.uk" + path })
 
   var currentUrl = origin + path;

--- a/src/popup/extract_path.js
+++ b/src/popup/extract_path.js
@@ -11,7 +11,7 @@ Popup.extractPath = function(location, pathname, renderingApplication) {
   else if (location.match(/anonymous_feedback/)) {
     extractedPath = extractQueryParameter(location, 'path');
   }
-  else if (location.match(/content-data-admin/)) {
+  else if (location.match(/content-data/)) {
     extractedPath = pathname.replace('metrics/', '');;
   }
   else if (location.match(/nationalarchives.gov.uk/)) {


### PR DESCRIPTION
Content Data Admin app moved from `content-data-admin.publishing.service.gov.uk` to `content-data.publishing.service.gov.uk` years ago.