### PR TITLE
Prevent event bubbling

### DIFF
--- a/src/components/highlight-component/highlight-component.js
+++ b/src/components/highlight-component/highlight-component.js
@@ -43,7 +43,9 @@ function HighlightComponent () {
     component.element.setAttribute('data-app-name', component.prefix)
 
     // the method will add a click event (listener), it'll then open a new window with the documentationUrl for that component.
-    component.element.addEventListener('click', function () {
+    component.element.addEventListener('click', function (event) {
+      event.stopPropagation() // prevent event bubbling
+      event.preventDefault()
       if (this.isComponentsHighlighted) {
         window.open(Helpers.documentationUrl(component))
       }


### PR DESCRIPTION
## What

Clicking any of the components on the page whilst using highlight component opens up two tabs: Public layout and whichever highlighted component was selected.

For some reason, when clicking the word Search on the [gov.uk](http://gov.uk/) homepage, whilst highlight components is on opens up 4 tabs.

## Why

So that the correct component guide tab opens when a component is clicked and only once.


https://trello.com/c/7MGCF3gV/2364-highlight-components