### PR TITLE
Rename job to `test` so it can be set as required status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 jobs:
-  run-jasmine:
+  test:
     name: Test Extension JS
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
govuk-saas-config [looks for](https://github.com/alphagov/govuk-saas-config/blob/395a713522985d7cdfc9ef5320892cace7a72042/github/lib/configure_repo.rb#L115-L120) a job named `test`, and sets this as a 'required' status check if it exists.

Defining one here means we'll ensure that tests have to pass in order for PRs to be merged, which is standard best practice.

Trello: https://trello.com/c/3CYpdFw4/3480-set-stricter-branch-protection-defaults