### PR TITLE
Add missing SCA / SAST scans to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,16 @@ on:
   pull_request:
 
 jobs:
+  codeql-sast:
+    name: CodeQL SAST scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main
+    permissions:
+      security-events: write
+
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
+
   test:
     name: Test Extension JS
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will resolve the alert at https://gds.slack.com/archives/C02L13S214K/p1714381348726429.

NB, this took a bit of effort! We were [seeing](https://github.com/alphagov/govuk-browser-extension/actions/runs/9283183060/job/25542847886?pr=196) an error with the default code analysis:

```
Extracting javascript
Extracting ruby
Finalizing javascript
Finalizing ruby
  /opt/hostedtoolcache/CodeQL/2.17.1/x64/codeql/codeql database finalize --finalize-dataset --threads=4 --ram=14567 /home/runner/work/_temp/codeql_databases/ruby
  CodeQL detected code written in JavaScript/TypeScript, but not any written in Ruby. Confirm that there is some source code for Ruby in the project. For more information, review our troubleshooting guide at https://gh.io/troubleshooting-code-scanning/no-source-code-seen-during-build .
  Error: Encountered a fatal error while running "/opt/hostedtoolcache/CodeQL/2.17.1/x64/codeql/codeql database finalize --finalize-dataset --threads=4 --ram=14567 /home/runner/work/_temp/codeql_databases/ruby". Exit code was 32 and last log line was: CodeQL detected code written in JavaScript/TypeScript, but not any written in Ruby. Confirm that there is some source code for Ruby in the project. For more information, review our troubleshooting guide at https://gh.io/troubleshooting-code-scanning/no-source-code-seen-during-build . See the logs for more details.
```

We explored configuring the [reusable workflow](https://github.com/alphagov/govuk-infrastructure/blob/main/.github/workflows/codeql-analysis.yml) to take a `languages` input, but there [doesn't seem to be a way of defaulting to 'undefined'](https://github.com/actions/runner/issues/924) if the parameter isn't passed, meaning we'd have to set a default of, say, 'ruby'. This would break the workflow for repos that may already be working with both Ruby and JS, where they'd be forced to pass the `languages` parameter now.

We also explored setting up CodeQL directly within the GitHub UI and explicitly opting out of Ruby to have JS only, but the reusable workflow still does a language detection and runs both JS and Ruby scans (the "JS only" scan appears as a separate job called "CodeQL / Analyze (javascript-typescript) (dynamic)"):

![Screenshot 2024-05-29 at 09 50 26](https://github.com/alphagov/govuk-browser-extension/assets/5111927/114bb17b-ac2e-4f42-8560-a0df69a49178)

Eventually, on closer inspection, we found that the only ruby in this project was a disused Rakefile, so we removed it in https://github.com/alphagov/govuk-browser-extension/pull/198. Now the CodeQL scan passes.