### PR TITLE
Add instructions for Firefox V3 workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ is open and are removed on exit. Permanently-active extensions can be only be
 installed from packages signed by Mozilla.
 
 1. [Download the source from GitHub](https://github.com/alphagov/govuk-browser-extension/archive/master.zip) and unzip.
-2. Visit [about:debugging](about:debugging) in your browser.
+2. Remove the `background` section from `src/manifest.json`. The service worker specified in this section changes the colour of the icon when on a GOV.UK page, but it relies on `background.service_worker`, which is [currently unsupported in Firefox with Manifest V3](https://bugzilla.mozilla.org/show_bug.cgi?id=1573659).
+3. Visit [about:debugging](about:debugging) in your browser.
 4. Click `Load Temporary Add-on` to pop up a file selection dialog.
 5. Navigate to `src` in the extension directory, and select `manifest.json`.
 6. Visit any page on [GOV.UK](https://www.gov.uk).


### PR DESCRIPTION
In its current state, and presumably since the [Manifest V3 migration](https://github.com/alphagov/govuk-browser-extension/pull/186), the extension doesn't work on Firefox. However, it can be made fully functional with a small change

When loading the extension in Firefox, the following is reported

```
There was an error during the temporary add-on installation.

Error details

background.service_worker is currently disabled
```

Firefox doesn't currently support `background.service_worker` in Manifest V3: https://bugzilla.mozilla.org/show_bug.cgi?id=1573659. This property was added when migrating to V3:
https://github.com/alphagov/govuk-browser-extension/pull/186

If you remove this section from the manifest, it will work on V3. The only caveat is that the icon won't change when on a GOV.UK page

I also tried changing `service_worker` to `scripts` and using an array per [this
suggestion](https://github.com/mozilla/web-ext/issues/2532#issuecomment-1694330075), which also makes the extension functional, but doesn't make the icon-changing script work. I suspect the `icon.js` code would need updating for cross-browser support. Other suggestions later in that thread might be worth exploring, but it might make more sense to hold off until Firefox adds proper support if the user base is low