### PR TITLE
Only raise Dependabot PRs for production dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,6 @@ version: 2
 updates:
   - package-ecosystem: npm
     directory: /
+    dependency-type: production
     schedule:
       interval: daily


### PR DESCRIPTION
## What

As proposed in https://docs.google.com/document/d/19cdE2lJE4kdk9_FrAimuKmzScXoWWDTRfDWP92ZVfa4/edit, we're switching off Dependabot PRs for NPM modules devDependencies. Production dependencies and security vulnerabilities will continue to have Dependabot PRs raised automatically.

## Why

When an NPM dependency bump breaks CI, it is a significant effort to wrestle with the NPM ecosystem of conflicting peer dependencies etc (especially on a team of mostly Ruby developers). The benefit to doing this work is also minimal, since none of our NPM modules are under active development.

The trade-off is that if we want to make a change to one of our NPM repos in future, we may have to update its build/test infrastructure if it has become obsolete in the meantime. But that's a big "if" - we _may_ save some future pain by battling through every dependency upgrade forever - whereas if we just _don't_ battle through dependency upgrades, we guarantee on saving ourselves from the pain of 'today' (and may never even encounter the pain of 'tomorrow', e.g. the component may just be retired!). If we _do_ start shipping updates to these modules in future, it will likely be just as simple to swap out the legacy test/build infrastructure for whatever is the latest fashion.

NB, we decided to keep the Dependabot updates for _production_ dependencies, which we likely _do_ want to stay current with.

---

Trello: https://trello.com/c/nuE5OhXh/3390-consider-the-ongoing-support-model-for-dependencies