### PR TITLE
Add content block highlighting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
         shell: bash
         run: npm install
 
+      - name: Lint
+        run: npm run lint:js
+
       - name: Run Jasmine
         run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   },
   "scripts": {
     "lint:js": "standardx 'spec/javascripts/**/*.js' 'src/**/*.js'",
-    "lint:js:fix": "npm run lint:js --fix",
+    "lint:js:fix": "npm run lint:js -- --fix",
     "test": "jasmine-browser-runner runSpecs",
     "build": "bash build.sh"
   },

--- a/spec/javascripts/content_blocks_component.spec.js
+++ b/spec/javascripts/content_blocks_component.spec.js
@@ -84,7 +84,7 @@ describe('Content blocks component', function () {
 
   describe('When no content blocks are present on a page', function () {
     beforeEach(function () {
-      loadFixtures("app-c-back-to-top.html")
+      loadFixtures('app-c-back-to-top.html')
 
       contentBlocksComponent = new ContentBlocksComponent()
       contentBlocksComponent.toggleHighlight()

--- a/spec/javascripts/content_blocks_component.spec.js
+++ b/spec/javascripts/content_blocks_component.spec.js
@@ -15,66 +15,85 @@ describe('Content blocks component', function () {
         sendMessage: function () {}
       }
     }
-
-    loadFixtures('content-blocks.html')
-
-    contentBlocksComponent = new ContentBlocksComponent()
-    contentBlocksComponent.toggleHighlight()
-
-    banner = document.querySelector('.govuk-chrome-content-blocks-banner')
   })
 
-  it('highlights content blocks', function () {
-    var contentBlocks = document.querySelectorAll('.content-embed')
+  describe('when a page has content blocks', function () {
+    beforeEach(function () {
+      loadFixtures('content-blocks.html')
 
-    contentBlocks.forEach(function (el) {
-      expect(el).toHaveClass('highlight-content-block')
-    })
-  })
+      contentBlocksComponent = new ContentBlocksComponent()
+      contentBlocksComponent.toggleHighlight()
 
-  it('shows content blocks in the banner', function () {
-    expect(banner).not.toBeNullish()
-
-    var header = banner.querySelector('.govuk-chrome-content-blocks-banner__heading')
-    var subheading = banner.querySelector('.govuk-chrome-content-blocks-banner__subhead')
-    var buttons = banner.querySelectorAll('.govuk-chrome-content-blocks-banner__button')
-
-    expect(header.innerText).toEqual('Content Blocks')
-    expect(subheading.innerText).toEqual('email address - enquiries@companieshouse.gov.uk')
-    expect(buttons.length).toEqual(2)
-  })
-
-  it('allows content blocks to be linked to', function () {
-    var realGetElementById = document.getElementById
-    var buttons = banner.querySelectorAll('.govuk-chrome-content-blocks-banner__button')
-
-    var stubs = Array.from(buttons).map(function (button) {
-      var stub = document.createElement('span')
-      stub.setAttribute('id', button.dataset.contentBlockId)
-      return stub
+      banner = document.querySelector('.govuk-chrome-content-blocks-banner')
     })
 
-    spyOn(document, 'getElementById').and.callFake(function (id) {
-      var stub = stubs.find(function (stub) {
-        return stub.getAttribute('id') === id
+    it('highlights content blocks', function () {
+      var contentBlocks = document.querySelectorAll('.content-embed')
+
+      contentBlocks.forEach(function (el) {
+        expect(el).toHaveClass('highlight-content-block')
       })
+    })
 
-      if (stub) {
+    it('shows content blocks in the banner', function () {
+      expect(banner).not.toBeNullish()
+
+      var header = banner.querySelector('.govuk-chrome-content-blocks-banner__heading')
+      var subheading = banner.querySelector('.govuk-chrome-content-blocks-banner__subhead')
+      var buttons = banner.querySelectorAll('.govuk-chrome-content-blocks-banner__button')
+
+      expect(header.innerText).toEqual('Content Blocks')
+      expect(subheading.innerText).toEqual('email address - enquiries@companieshouse.gov.uk')
+      expect(buttons.length).toEqual(2)
+    })
+
+    it('allows content blocks to be linked to', function () {
+      var realQuerySelector = document.querySelector
+      var buttons = banner.querySelectorAll('.govuk-chrome-content-blocks-banner__button')
+
+      var stubs = Array.from(buttons).map(function (button) {
+        var stub = document.createElement('span')
+        stub.setAttribute('data-content-block-page-identifier', button.dataset.contentBlockTarget)
         return stub
-      } else {
-        return realGetElementById.call(document, id)
-      }
+      })
+
+      spyOn(document, 'querySelector').and.callFake(function (selector) {
+        var stub = stubs.find(function (stub) {
+          return stub.matches(selector)
+        })
+
+        if (stub) {
+          return stub
+        } else {
+          return realQuerySelector.call(document, selector)
+        }
+      })
+
+      buttons.forEach(function (button) {
+        var stub = stubs.find(function (stub) {
+          return stub.dataset.contentBlockPageIdentifier === button.dataset.contentBlockTarget
+        })
+        var scrollspy = spyOn(stub, 'scrollIntoView')
+
+        button.dispatchEvent(new Event('click'))
+
+        expect(scrollspy).toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('When no content blocks are present on a page', function () {
+    beforeEach(function () {
+      loadFixtures("app-c-back-to-top.html")
+
+      contentBlocksComponent = new ContentBlocksComponent()
+      contentBlocksComponent.toggleHighlight()
+
+      banner = document.querySelector('.govuk-chrome-content-blocks-banner')
     })
 
-    buttons.forEach(function (button) {
-      var stub = stubs.find(function (stub) {
-        return stub.getAttribute('id') === button.dataset.contentBlockId
-      })
-      var scrollspy = spyOn(stub, 'scrollIntoView')
-
-      button.dispatchEvent(new Event('click'))
-
-      expect(scrollspy).toHaveBeenCalled()
+    it('shows a message', function () {
+      expect(banner.innerText).toMatch('No content blocks in use on this page')
     })
   })
 })

--- a/spec/javascripts/content_blocks_component.spec.js
+++ b/spec/javascripts/content_blocks_component.spec.js
@@ -1,0 +1,80 @@
+'use strict'
+
+/* global ContentBlocksComponent loadFixtures */
+
+describe('Content blocks component', function () {
+  var banner
+  var contentBlocksComponent
+
+  beforeEach(function () {
+    window.chrome = {
+      runtime: {
+        onMessage: {
+          addListener: function () {}
+        },
+        sendMessage: function () {}
+      }
+    }
+
+    loadFixtures('content-blocks.html')
+
+    contentBlocksComponent = new ContentBlocksComponent()
+    contentBlocksComponent.toggleHighlight()
+
+    banner = document.querySelector('.govuk-chrome-content-blocks-banner')
+  })
+
+  it('highlights content blocks', function () {
+    var contentBlocks = document.querySelectorAll('.content-embed')
+
+    contentBlocks.forEach(function (el) {
+      expect(el).toHaveClass('highlight-content-block')
+    })
+  })
+
+  it('shows content blocks in the banner', function () {
+    expect(banner).not.toBeNullish()
+
+    var header = banner.querySelector('.govuk-chrome-content-blocks-banner__heading')
+    var subheading = banner.querySelector('.govuk-chrome-content-blocks-banner__subhead')
+    var buttons = banner.querySelectorAll('.govuk-chrome-content-blocks-banner__button')
+
+    expect(header.innerText).toEqual('Content Blocks')
+    expect(subheading.innerText).toEqual('email address - enquiries@companieshouse.gov.uk')
+    expect(buttons.length).toEqual(2)
+  })
+
+  it('allows content blocks to be linked to', function () {
+    var realGetElementById = document.getElementById
+    var buttons = banner.querySelectorAll('.govuk-chrome-content-blocks-banner__button')
+
+    var stubs = Array.from(buttons).map(function (button) {
+      var stub = document.createElement('span')
+      stub.setAttribute('id', button.dataset.contentBlockId)
+      return stub
+    })
+
+    spyOn(document, 'getElementById').and.callFake(function (id) {
+      var stub = stubs.find(function (stub) {
+        return stub.getAttribute('id') === id
+      })
+
+      if (stub) {
+        return stub
+      } else {
+        return realGetElementById.call(document, id)
+      }
+    })
+
+    buttons.forEach(function (button) {
+      var stub = stubs.find(function (stub) {
+        return stub.getAttribute('id') === button.dataset.contentBlockId
+      })
+      var scrollspy = spyOn(stub, 'scrollIntoView')
+
+      button.dispatchEvent(new Event('click'))
+
+      expect(scrollspy).toHaveBeenCalled()
+    })
+  })
+})

--- a/spec/javascripts/fixtures/content-blocks.html
+++ b/spec/javascripts/fixtures/content-blocks.html
@@ -1,0 +1,9 @@
+<h1>Hello!</h1>
+
+<p>Here is some text</p>
+
+<p><span class="content-embed content-embed__content_block_email_address" data-content-block="" data-document-type="content_block_email_address" data-content-id="daaaf3c4-8b55-47a7-8116-e5a4d71ce1de" data-embed-code="{{embed:content_block_email_address:companies-house-enquiries}}">enquiries@companieshouse.gov.uk</span></p>
+
+<p>And some more text</p>
+
+<p><span class="content-embed content-embed__content_block_email_address" data-content-block="" data-document-type="content_block_email_address" data-content-id="daaaf3c4-8b55-47a7-8116-e5a4d71ce1de" data-embed-code="{{embed:content_block_email_address:companies-house-enquiries}}">enquiries@companieshouse.gov.uk</span></p>

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -8,12 +8,14 @@
     "popup/environment.js",
     "popup/extract_path.js",
     "popup/external_links.js",
+    "components/content-blocks-component/content-blocks-component.js",
     "components/highlight-component/highlight-component.js",
     "components/design-mode-component/design-mode-component.js",
     "components/show-meta-tags-component/show-meta-tags-component.js"
   ],
   "specDir": "spec",
   "specFiles": [
+    "**/content_blocks_component.spec.js",
     "**/show_meta_tags.spec.js",
     "**/highlight_component.spec.js",
     "**/extract_path.spec.js",

--- a/src/components/content-blocks-component/content-blocks-component.css
+++ b/src/components/content-blocks-component/content-blocks-component.css
@@ -1,0 +1,33 @@
+.highlight-content-block {
+    cursor: pointer;
+    background-color: #ffdd00;
+    position: relative;
+}
+
+.highlight-content-block:hover:after {
+    background-color: #ffdd00;
+    color: #0B0C0C;
+    content: attr(data-document-type);
+    font-family: sans-serif;
+    font-size: 12px;
+    font-weight: normal;
+    padding-left: 3px;
+    padding-bottom: 3px;
+    position: absolute;
+    left: 0;
+    top: 100%;
+    z-index: 1;
+}
+
+.govuk-chrome-content-blocks-banner {
+    padding: 20px;
+    background-color: #f3f2f1;
+}
+
+.govuk-chrome-content-blocks-banner__subhead:first-letter {
+    text-transform: uppercase;
+}
+
+.govuk-chrome-content-blocks-banner__button {
+    margin-left: 10px;
+}

--- a/src/components/content-blocks-component/content-blocks-component.js
+++ b/src/components/content-blocks-component/content-blocks-component.js
@@ -44,38 +44,42 @@ ContentBlocksComponent.prototype.showContentBlocksBanner = function () {
 
   wrapper.insertAdjacentHTML('beforeend', title)
 
-  var instances = Map.groupBy(this.contentBlocks, function (contentBlock) {
-    var documentType = contentBlock.dataset.documentType.replace('content_block', '').replaceAll('_', ' ')
-    return `${documentType} - ${contentBlock.innerText}`
-  })
+  if (this.contentBlocks.length) {
+    var instances = Map.groupBy(this.contentBlocks, function (contentBlock) {
+      var documentType = contentBlock.dataset.documentType.replace('content_block', '').replaceAll('_', ' ')
+      return `${documentType} - ${contentBlock.innerText}`
+    })
 
-  instances.forEach(function (blocks, category) {
-    var blockTitle = `<h3 class="govuk-chrome-content-blocks-banner__subhead govuk-heading-s">
+    instances.forEach(function (blocks, category) {
+      var blockTitle = `<h3 class="govuk-chrome-content-blocks-banner__subhead govuk-heading-s">
             ${category}
         </h3>`
-    wrapper.insertAdjacentHTML('beforeend', blockTitle)
-    var output = ''
+      wrapper.insertAdjacentHTML('beforeend', blockTitle)
+      var output = ''
 
-    blocks.forEach(function (contentBlock, index) {
-      output += `
+      blocks.forEach(function (contentBlock, index) {
+        output += `
                 <a class="govuk-button govuk-chrome-content-blocks-banner__button" 
                    data-content-block-target="${contentBlock.dataset.contentBlockPageIdentifier}"
                 >
                     Jump to instance ${index + 1}
                 </a>`
+      })
+
+      wrapper.insertAdjacentHTML('beforeend', output)
     })
 
-    wrapper.insertAdjacentHTML('beforeend', output)
-  })
-
-  wrapper.querySelectorAll('.govuk-chrome-content-blocks-banner__button').forEach(function (element) {
-    element.addEventListener('click', function (e) {
-      e.preventDefault()
-      var id = e.target.dataset.contentBlockId
-      var element = document.getElementById(id)
-      element.scrollIntoView()
+    wrapper.querySelectorAll('.govuk-chrome-content-blocks-banner__button').forEach(function (element) {
+      element.addEventListener('click', function (e) {
+        e.preventDefault()
+        var id = e.target.dataset.contentBlockTarget
+        var element = document.querySelector(`[data-content-block-page-identifier=${id}]`)
+        element.scrollIntoView()
+      })
     })
-  })
+  } else {
+    wrapper.insertAdjacentHTML('beforeend', "<p>No content blocks in use on this page</p>")
+  }
 
   document.body.prepend(wrapper)
 }

--- a/src/components/content-blocks-component/content-blocks-component.js
+++ b/src/components/content-blocks-component/content-blocks-component.js
@@ -78,7 +78,7 @@ ContentBlocksComponent.prototype.showContentBlocksBanner = function () {
       })
     })
   } else {
-    wrapper.insertAdjacentHTML('beforeend', "<p>No content blocks in use on this page</p>")
+    wrapper.insertAdjacentHTML('beforeend', '<p>No content blocks in use on this page</p>')
   }
 
   document.body.prepend(wrapper)

--- a/src/components/content-blocks-component/content-blocks-component.js
+++ b/src/components/content-blocks-component/content-blocks-component.js
@@ -1,0 +1,88 @@
+'use strict'
+
+function ContentBlocksComponent () {
+  this.contentBlocksHighlighted = false
+  this.contentBlocks = Array.from(document.querySelectorAll('.content-embed'))
+
+  chrome.runtime.onMessage.addListener(function (request) {
+    if (request.trigger === 'toggleContentBlocks') {
+      this.toggleHighlight()
+    }
+  }.bind(this))
+}
+
+ContentBlocksComponent.prototype.toggleHighlight = function () {
+  for (var i = 0; i < this.contentBlocks.length; i++) {
+    this.contentBlocks[i].classList.toggle('highlight-content-block', !this.contentBlocksHighlighted)
+    this.contentBlocks[i].setAttribute('data-content-block-page-identifier', `content_block_${i}`)
+  }
+
+  if (this.contentBlocksHighlighted) {
+    this.hideContentBlocksBanner()
+  } else {
+    this.showContentBlocksBanner()
+  }
+
+  this.contentBlocksHighlighted = !this.contentBlocksHighlighted
+
+  this.sendState()
+}
+
+ContentBlocksComponent.prototype.hideContentBlocksBanner = function () {
+  var wrapper = document.querySelector('.govuk-chrome-content-blocks-banner')
+
+  wrapper.remove()
+}
+
+ContentBlocksComponent.prototype.showContentBlocksBanner = function () {
+  var wrapper = document.createElement('div')
+  wrapper.classList.add('govuk-chrome-content-blocks-banner')
+
+  var title = `<h2 class="govuk-chrome-content-blocks-banner__heading govuk-heading-m">
+      Content Blocks
+    </h2>`
+
+  wrapper.insertAdjacentHTML('beforeend', title)
+
+  var instances = Map.groupBy(this.contentBlocks, function (contentBlock) {
+    var documentType = contentBlock.dataset.documentType.replace('content_block', '').replaceAll('_', ' ')
+    return `${documentType} - ${contentBlock.innerText}`
+  })
+
+  instances.forEach(function (blocks, category) {
+    var blockTitle = `<h3 class="govuk-chrome-content-blocks-banner__subhead govuk-heading-s">
+            ${category}
+        </h3>`
+    wrapper.insertAdjacentHTML('beforeend', blockTitle)
+    var output = ''
+
+    blocks.forEach(function (contentBlock, index) {
+      output += `
+                <a class="govuk-button govuk-chrome-content-blocks-banner__button" 
+                   data-content-block-target="${contentBlock.dataset.contentBlockPageIdentifier}"
+                >
+                    Jump to instance ${index + 1}
+                </a>`
+    })
+
+    wrapper.insertAdjacentHTML('beforeend', output)
+  })
+
+  wrapper.querySelectorAll('.govuk-chrome-content-blocks-banner__button').forEach(function (element) {
+    element.addEventListener('click', function (e) {
+      e.preventDefault()
+      var id = e.target.dataset.contentBlockId
+      var element = document.getElementById(id)
+      element.scrollIntoView()
+    })
+  })
+
+  document.body.prepend(wrapper)
+}
+
+ContentBlocksComponent.prototype.sendState = function () {
+  chrome.runtime.sendMessage({
+    action: 'contentBlockState',
+    highlightState: this.contentBlocksHighlighted
+  })
+}

--- a/src/manifest_base.json
+++ b/src/manifest_base.json
@@ -14,11 +14,13 @@
       "js": [
         "popup/lib/mustache.min.js",
         "components/highlight-component/highlight-component.js",
+        "components/content-blocks-component/content-blocks-component.js",
         "components/design-mode-component/design-mode-component.js",
         "components/show-meta-tags-component/show-meta-tags-component.js"
       ],
       "css": [
         "components/highlight-component/highlight-component.css",
+        "components/content-blocks-component/content-blocks-component.css",
         "components/design-mode-component/design-mode-component.css",
         "components/show-meta-tags-component/show-meta-tags-component.css"
       ]

--- a/src/popup.html
+++ b/src/popup.html
@@ -33,6 +33,9 @@
         <a href='#' id='highlight-components'>Highlight Components</a>
       </li>
       <li>
+        <a href='#' id='highlight-content-blocks'>Highlight Content Blocks</a>
+      </li>
+      <li>
         <a href='#' id='highlight-meta-tags'>Show meta tags</a>
       </li>
       <li>

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,3 +1,5 @@
+/* global HighlightComponent ContentBlocksComponent DesignModeComponent ShowMetaTagsComponent tab */
+
 // This script is executed when the popup is opened.
 var Popup = Popup || {};
 
@@ -6,22 +8,22 @@ var Popup = Popup || {};
   // loaded page). This script will call back to us.
 
   document.addEventListener('DOMContentLoaded', async () => {
-    let queryOptions = { active: true, lastFocusedWindow: true };
+    const queryOptions = { active: true, lastFocusedWindow: true }
     // `tab` will either be a `tabs.Tab` instance or `undefined`.
-    let [tab] = await chrome.tabs.query(queryOptions);
+    const [tab] = await chrome.tabs.query(queryOptions)
 
     chrome.scripting.executeScript({
-      target: {tabId: tab.id},
+      target: { tabId: tab.id },
       func: () => {
-        window.highlightComponent = window.highlightComponent || new HighlightComponent
-        window.higlightContentBlocksComponent = window.higlightContentBlocksComponent || new ContentBlocksComponent
-        window.designModeComponent = window.designModeComponent || new DesignModeComponent
-        window.showMetaTagsComponent = window.showMetaTagsComponent || new ShowMetaTagsComponent
+        window.highlightComponent = window.highlightComponent || new HighlightComponent()
+        window.higlightContentBlocksComponent = window.higlightContentBlocksComponent || new ContentBlocksComponent()
+        window.designModeComponent = window.designModeComponent || new DesignModeComponent()
+        window.showMetaTagsComponent = window.showMetaTagsComponent || new ShowMetaTagsComponent()
       }
     })
 
     chrome.scripting.executeScript({
-      target: {tabId: tab.id},
+      target: { tabId: tab.id },
       files: ['fetch-page-data.js']
     })
   })
@@ -33,45 +35,45 @@ var Popup = Popup || {};
     switch (request.action) {
       case 'populatePopup':
         renderPopup(
-            request.currentLocation,
-            request.currentHost,
-            request.currentOrigin,
-            request.currentPathname,
-            request.renderingApplication,
-            request.windowHeight,
-            null // abTestBuckets
+          request.currentLocation,
+          request.currentHost,
+          request.currentOrigin,
+          request.currentPathname,
+          request.renderingApplication,
+          request.windowHeight,
+          null // abTestBuckets
         )
         break
       case 'highlightState':
         toggleLinkText(
-            '#highlight-components',
-            'Stop highlighting components',
-            'Highlight Components',
-            request.highlightState
+          '#highlight-components',
+          'Stop highlighting components',
+          'Highlight Components',
+          request.highlightState
         )
         break
       case 'contentBlockState':
         toggleLinkText(
-            '#highlight-content-blocks',
-            'Stop highlighting content blocks',
-            'Highlight Content Blocks',
-            request.highlightState
+          '#highlight-content-blocks',
+          'Stop highlighting content blocks',
+          'Highlight Content Blocks',
+          request.highlightState
         )
         break
       case 'showMetaTagsState':
         toggleLinkText(
-            '#highlight-meta-tags',
-            'Hide meta tags',
-            'Show meta tags',
-            request.metaTagsState
+          '#highlight-meta-tags',
+          'Hide meta tags',
+          'Show meta tags',
+          request.metaTagsState
         )
         break
       case 'designModeState':
         toggleLinkText(
-            '#toggle-design-mode',
-            'Turn off design mode',
-            'Turn on design mode',
-            request.designModeState
+          '#toggle-design-mode',
+          'Turn off design mode',
+          'Turn on design mode',
+          request.designModeState
         )
         break
       default:
@@ -79,7 +81,7 @@ var Popup = Popup || {};
     }
   })
 
-  function toggleLinkText(selector, onValue, offValue, state) {
+  function toggleLinkText (selector, onValue, offValue, state) {
     var toggleLink = document.querySelector(selector)
     if (state) {
       toggleLink.textContent = onValue
@@ -129,12 +131,12 @@ var Popup = Popup || {};
 
     setupAbToggles(currentUrl)
 
-    let queryOptions = { active: true, lastFocusedWindow: true };
+    const queryOptions = { active: true, lastFocusedWindow: true }
     // `tab` will either be a `tabs.Tab` instance or `undefined`.
-    let [tab] = await chrome.tabs.query(queryOptions);
+    const [tab] = await chrome.tabs.query(queryOptions)
 
     chrome.scripting.executeScript({
-      target: {tabId: tab.id},
+      target: { tabId: tab.id },
       func: () => {
         window.highlightComponent.sendState()
         window.higlightContentBlocksComponent.sendState()
@@ -232,7 +234,7 @@ var Popup = Popup || {};
             chrome.tabs.reload(tab.id, { bypassCache: true })
           }
         )
-1      })
+      })
     })
   }
 

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -14,6 +14,7 @@ var Popup = Popup || {};
       target: {tabId: tab.id},
       func: () => {
         window.highlightComponent = window.highlightComponent || new HighlightComponent
+        window.higlightContentBlocksComponent = window.higlightContentBlocksComponent || new ContentBlocksComponent
         window.designModeComponent = window.designModeComponent || new DesignModeComponent
         window.showMetaTagsComponent = window.showMetaTagsComponent || new ShowMetaTagsComponent
       }
@@ -46,6 +47,14 @@ var Popup = Popup || {};
             '#highlight-components',
             'Stop highlighting components',
             'Highlight Components',
+            request.highlightState
+        )
+        break
+      case 'contentBlockState':
+        toggleLinkText(
+            '#highlight-content-blocks',
+            'Stop highlighting content blocks',
+            'Highlight Content Blocks',
             request.highlightState
         )
         break
@@ -128,6 +137,7 @@ var Popup = Popup || {};
       target: {tabId: tab.id},
       func: () => {
         window.highlightComponent.sendState()
+        window.higlightContentBlocksComponent.sendState()
         window.showMetaTagsComponent.sendState()
         window.designModeComponent.sendState()
       }
@@ -178,6 +188,11 @@ var Popup = Popup || {};
     document.querySelector('#highlight-components').addEventListener('click', function (e) {
       e.preventDefault()
       sendChromeTabMessage('toggleComponents')
+    })
+
+    document.querySelector('#highlight-content-blocks').addEventListener('click', function (e) {
+      e.preventDefault()
+      sendChromeTabMessage('toggleContentBlocks')
     })
 
     document.querySelector('#highlight-meta-tags').addEventListener('click', function (e) {

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -29,46 +29,55 @@ var Popup = Popup || {};
   // fetch-page-data.js (called above). It will forward the location to our main
   // render function.
   chrome.runtime.onMessage.addListener(function (request, _sender) {
-    if (request.action === 'populatePopup') {
-      // When we're asked to populate the popup, we'll first send the current
-      // buckets back to the main thread, which "persists" them.
-      //var abTestSettings = chrome.extension.getBackgroundPage().abTestSettings
-      // var abTestBuckets = abTestSettings.initialize(request.abTestBuckets, request.currentLocation)
-
-      renderPopup(
-        request.currentLocation,
-        request.currentHost,
-        request.currentOrigin,
-        request.currentPathname,
-        request.renderingApplication,
-        request.windowHeight,
-        null // abTestBuckets
-      )
+    switch (request.action) {
+      case 'populatePopup':
+        renderPopup(
+            request.currentLocation,
+            request.currentHost,
+            request.currentOrigin,
+            request.currentPathname,
+            request.renderingApplication,
+            request.windowHeight,
+            null // abTestBuckets
+        )
+        break
+      case 'highlightState':
+        toggleLinkText(
+            '#highlight-components',
+            'Stop highlighting components',
+            'Highlight Components',
+            request.highlightState
+        )
+        break
+      case 'showMetaTagsState':
+        toggleLinkText(
+            '#highlight-meta-tags',
+            'Hide meta tags',
+            'Show meta tags',
+            request.metaTagsState
+        )
+        break
+      case 'designModeState':
+        toggleLinkText(
+            '#toggle-design-mode',
+            'Turn off design mode',
+            'Turn on design mode',
+            request.designModeState
+        )
+        break
+      default:
+        break
     }
   })
 
-  chrome.runtime.onMessage.addListener(function (request, _sender) {
-    if (request.action === 'highlightState') {
-      // When we're asked to populate the popup, we'll first send the current
-      // buckets back to the main thread, which "persists" them.
-      if (request.highlightState) { document.querySelector('#highlight-components').textContent = 'Stop highlighting components' } else { document.querySelector('#highlight-components').textContent = 'Highlight Components' }
+  function toggleLinkText(selector, onValue, offValue, state) {
+    var toggleLink = document.querySelector(selector)
+    if (state) {
+      toggleLink.textContent = onValue
+    } else {
+      toggleLink.textContent = offValue
     }
-  })
-
-  chrome.runtime.onMessage.addListener(function (request, _sender) {
-    if (request.action === 'showMetaTagsState') {
-      // When we're asked to populate the popup, we'll first send the current
-      // buckets back to the main thread, which "persists" them.
-      if (request.metaTagsState) { document.querySelector('#highlight-meta-tags').textContent = 'Hide meta tags' } else { document.querySelector('#highlight-meta-tags').textContent = 'Show meta tags' }
-    }
-  })
-
-  chrome.runtime.onMessage.addListener(function (request, _sender) {
-    if (request.action === 'designModeState') {
-      var toggleLink = document.querySelector('#toggle-design-mode')
-      if (request.designModeState) { toggleLink.textContent = 'Turn off design mode' } else { toggleLink.textContent = 'Turn on design mode' }
-    }
-  })
+  }
 
   // Render the popup.
   function renderPopup (location, hostname, origin, pathname, renderingApplication, windowHeight, abTestBuckets) {

--- a/src/service_utils/icon.js
+++ b/src/service_utils/icon.js
@@ -4,34 +4,34 @@ chrome.declarativeContent.onPageChanged.removeRules(async () => {
   chrome.declarativeContent.onPageChanged.addRules([{
     conditions: [
       new chrome.declarativeContent.PageStateMatcher({
-        pageUrl: { hostSuffix: 'www.gov.uk' },
+        pageUrl: { hostSuffix: 'www.gov.uk' }
       }),
       new chrome.declarativeContent.PageStateMatcher({
-        pageUrl: { hostSuffix: 'dev.gov.uk' },
+        pageUrl: { hostSuffix: 'dev.gov.uk' }
       }),
       new chrome.declarativeContent.PageStateMatcher({
-        pageUrl: { hostSuffix: 'publishing.service.gov.uk' },
-      }),
+        pageUrl: { hostSuffix: 'publishing.service.gov.uk' }
+      })
     ],
     actions: [
       new chrome.declarativeContent.SetIcon({
         imageData: {
-          19: await loadImageData("icons/crown-logo-19-active.png"),
-          38: await loadImageData("icons/crown-logo-38-active.png"),
-        },
+          19: await loadImageData('icons/crown-logo-19-active.png'),
+          38: await loadImageData('icons/crown-logo-38-active.png')
+        }
       }),
       chrome.declarativeContent.ShowAction
         ? new chrome.declarativeContent.ShowAction()
-        : new chrome.declarativeContent.ShowPageAction(),
-    ],
-  }]);
-});
+        : new chrome.declarativeContent.ShowPageAction()
+    ]
+  }])
+})
 
-async function loadImageData(url) {
-  const img = await createImageBitmap(await (await fetch(url)).blob());
-  const {width: w, height: h} = img;
-  const canvas = new OffscreenCanvas(w, h);
-  const ctx = canvas.getContext('2d');
-  ctx.drawImage(img, 0, 0, w, h);
-  return ctx.getImageData(0, 0, w, h);
+async function loadImageData (url) {
+  const img = await createImageBitmap(await (await fetch(url)).blob())
+  const { width: w, height: h } = img
+  const canvas = new OffscreenCanvas(w, h)
+  const ctx = canvas.getContext('2d')
+  ctx.drawImage(img, 0, 0, w, h)
+  return ctx.getImageData(0, 0, w, h)
 }

--- a/src/service_worker.js
+++ b/src/service_worker.js
@@ -1,1 +1,3 @@
-importScripts("./service_utils/icon.js")
+/* global importScripts */
+
+importScripts('./service_utils/icon.js')


### PR DESCRIPTION
Trello card: https://trello.com/c/JDtjEdz0/1009-allow-govuk-browser-extension-to-highlight-content-blocks

This adds a link to the extension to highlight content blocks that are in use on a page, as well as showing a link to navigate to each block

## Screenshots

![image](https://github.com/user-attachments/assets/3af2ac25-726f-464f-8461-48f98e1fa446)

![image](https://github.com/user-attachments/assets/9a0f6bb3-e3bf-41b2-aacc-c585cd7e6088)
