### PR TITLE
Small fixes: use rendering-app and prevent click breaking

### DIFF
--- a/spec/javascripts/highlight_component.spec.js
+++ b/spec/javascripts/highlight_component.spec.js
@@ -157,7 +157,7 @@ describe('highlightComponent', function () {
 
 describe('Helpers.documentationUrl', function () {
   it("creates the correct URL for 'app' components with substitution", function () {
-    setFixtures('<head><meta name="govuk:rendering-application" content="collections"></head>')
+    setFixtures('<head><meta name="govuk:rendering-app" content="collections"></head>')
     Helpers.substitutions = {
       collections: 'another_host'
     }
@@ -172,7 +172,7 @@ describe('Helpers.documentationUrl', function () {
   })
 
   it("creates the correct URL for 'app' components without substitution", function () {
-    setFixtures('<head><meta name="govuk:rendering-application" content="rendering_app"></head>')
+    setFixtures('<head><meta name="govuk:rendering-app" content="rendering_app"></head>')
     Helpers.substitutions = {
       collections: 'another_host'
     }
@@ -187,7 +187,7 @@ describe('Helpers.documentationUrl', function () {
   })
 
   it("creates the correct URL for 'gem' components", function () {
-    setFixtures('<head><meta name="govuk:rendering-application" content="rendering_app"></head>')
+    setFixtures('<head><meta name="govuk:rendering-app" content="rendering_app"></head>')
     Helpers.substitutions = {
       collections: 'another_host'
     }

--- a/src/components/highlight-component/highlight-component.js
+++ b/src/components/highlight-component/highlight-component.js
@@ -89,7 +89,7 @@ var Helpers = {
   },
 
   appHostname: function () {
-    var renderingElement = document.querySelector('meta[name="govuk:rendering-application"]')
+    var renderingElement = document.querySelector('meta[name="govuk:rendering-app"]')
     var renderingApp = renderingElement.getAttribute('content')
     return this.substitutions[renderingApp] || renderingApp
   }

--- a/src/components/highlight-component/highlight-component.js
+++ b/src/components/highlight-component/highlight-component.js
@@ -44,9 +44,9 @@ function HighlightComponent () {
 
     // the method will add a click event (listener), it'll then open a new window with the documentationUrl for that component.
     component.element.addEventListener('click', function (event) {
-      event.stopPropagation() // prevent event bubbling
-      event.preventDefault()
       if (this.isComponentsHighlighted) {
+        event.stopPropagation() // prevent event bubbling
+        event.preventDefault()
         window.open(Helpers.documentationUrl(component))
       }
     }.bind(this))

--- a/src/fetch-page-data.js
+++ b/src/fetch-page-data.js
@@ -8,7 +8,7 @@ chrome.runtime.sendMessage({
   currentHost: window.location.hostname,
   currentOrigin: window.location.origin,
   currentPathname: window.location.pathname,
-  renderingApplication: getMetatag('govuk:rendering-application'),
+  renderingApplication: getMetatag('govuk:rendering-app'),
   abTestBuckets: getAbTestBuckets(),
   windowHeight: window.innerHeight,
   highlightState: false // window.highlightComponent.state

--- a/src/manifest_base.json
+++ b/src/manifest_base.json
@@ -3,7 +3,7 @@
   "name": "GOV.UK Browser Extension",
   "description": "Switch between GOV.UK environments and content",
   "homepage_url": "https://github.com/alphagov/govuk-browser-extension",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "content_scripts": [
     {
       "matches":


### PR DESCRIPTION
A small PR to fix two problems:

- currently the extension relies on the meta tag `rendering-application` for a specific limited use case (deciding whether to show a smart answers menu item). Everything else looks for the `rendering-app` tag, so update to use that.
- currently popping up the extension (even if you do nothing else) renders all links in the page unclickable, because a listener that's used for the highlight components option is initialised and prevents defaults on all links. Update that to prevent defaults only if components are actually currently being highlighted.